### PR TITLE
refactor(persona): fix prompting pipeline and concurrency bugs

### DIFF
--- a/backend-test/ChatGroupGrainTest.cs
+++ b/backend-test/ChatGroupGrainTest.cs
@@ -93,6 +93,46 @@ public class ChatGroupGrainTest
         Assert.Single(state.Participants);
     }
 
+    [Fact]
+    public void Apply_InitializedEvent_PopulatesScenarioWhenProvided()
+    {
+        var state = new ChatGroupState();
+        state.Apply(new ChatGroupInitializedEvent
+        {
+            PartyId = _partyId,
+            Participants = [],
+            Scenario = "Office of a stealth horticulture startup."
+        });
+
+        Assert.Equal("Office of a stealth horticulture startup.", state.Scenario);
+    }
+
+    [Fact]
+    public void Apply_ScenarioSetEvent_UpdatesOnlyScenario()
+    {
+        var existingParticipant = new PartyParticipant { Id = Guid.NewGuid(), Name = "Alice" };
+        var state = NewState([existingParticipant]);
+        state.Apply(new ChatGroupScenarioSetEvent { Scenario = "After-hours bar." });
+
+        Assert.Equal("After-hours bar.", state.Scenario);
+        // Other state must be untouched.
+        Assert.Equal(_partyId, state.PartyId);
+        Assert.Single(state.Participants);
+        Assert.Equal(existingParticipant.Id, state.Participants[0].Id);
+    }
+
+    [Fact]
+    public void Apply_ScenarioSetEvent_NullClearsExistingScenario()
+    {
+        var state = NewState();
+        state.Apply(new ChatGroupScenarioSetEvent { Scenario = "Previous setting." });
+        Assert.Equal("Previous setting.", state.Scenario);
+
+        state.Apply(new ChatGroupScenarioSetEvent { Scenario = null });
+
+        Assert.Null(state.Scenario);
+    }
+
     // ── Slot reservation / monotonic IDs ─────────────────────────────────────
 
     [Fact]

--- a/backend-test/GenerationSessionTest.cs
+++ b/backend-test/GenerationSessionTest.cs
@@ -219,6 +219,82 @@ public class GenerationSessionTest
         yield return new LlmGenerationEvent(LlmGenerationEvent.ContentChunk, "second"); // unreachable
     }
 
+    // ── Scenario rendering ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Captures the LlmGenerationJob passed to the endpoint so tests can assert on the
+    /// rendered system prompt without coupling to the streaming pump.
+    /// </summary>
+    private static (Mock<ILlmEndpointGrain> endpoint, Func<LlmGenerationJob?> getJob) CapturingEndpoint()
+    {
+        LlmGenerationJob? captured = null;
+        var endpoint = new Mock<ILlmEndpointGrain>();
+        endpoint
+            .Setup(e => e.GenerateAsync(It.IsAny<LlmGenerationJob>(), It.IsAny<CancellationToken>()))
+            .Returns<LlmGenerationJob, CancellationToken>((job, ct) =>
+            {
+                captured = job;
+                return Emit([], ct);
+            });
+        return (endpoint, () => captured);
+    }
+
+    [Fact]
+    public async Task GenerateResponseOnlyAsync_WithScenario_RendersScenarioSectionInSystemPrompt()
+    {
+        var (endpoint, getJob) = CapturingEndpoint();
+        var persona = MakeParticipant("Vlad");
+        var session = new GenerationSession(RouterFor(endpoint).Object, [persona]);
+
+        await session.GenerateResponseOnlyAsync(
+            persona, [],
+            (_, _, _) => Task.CompletedTask,
+            CancellationToken.None,
+            turnInstruction: null,
+            scenario: "Office of a stealth horticulture startup.");
+
+        var systemMessage = getJob()!.Messages[0];
+        Assert.Equal("system", systemMessage.Role);
+        Assert.Contains("# Scenario", systemMessage.Content);
+        Assert.Contains("Office of a stealth horticulture startup.", systemMessage.Content);
+    }
+
+    [Fact]
+    public async Task GenerateResponseOnlyAsync_NullScenario_OmitsScenarioSection()
+    {
+        var (endpoint, getJob) = CapturingEndpoint();
+        var persona = MakeParticipant("Vlad");
+        var session = new GenerationSession(RouterFor(endpoint).Object, [persona]);
+
+        await session.GenerateResponseOnlyAsync(
+            persona, [],
+            (_, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        var systemMessage = getJob()!.Messages[0];
+        Assert.DoesNotContain("# Scenario", systemMessage.Content);
+    }
+
+    [Fact]
+    public async Task GenerateResponseOnlyAsync_WhitespaceScenario_OmitsScenarioSection()
+    {
+        // Whitespace-only scenario must be treated as "no scenario" so we don't emit an
+        // empty heading that confuses the model.
+        var (endpoint, getJob) = CapturingEndpoint();
+        var persona = MakeParticipant("Vlad");
+        var session = new GenerationSession(RouterFor(endpoint).Object, [persona]);
+
+        await session.GenerateResponseOnlyAsync(
+            persona, [],
+            (_, _, _) => Task.CompletedTask,
+            CancellationToken.None,
+            turnInstruction: null,
+            scenario: "   \n  ");
+
+        var systemMessage = getJob()!.Messages[0];
+        Assert.DoesNotContain("# Scenario", systemMessage.Content);
+    }
+
     // ── Error propagation ─────────────────────────────────────────────────────
 
     [Fact]

--- a/backend-test/PersonaDecisionServiceTest.cs
+++ b/backend-test/PersonaDecisionServiceTest.cs
@@ -249,6 +249,62 @@ public class PersonaDecisionServiceTest
     }
 
     [Fact]
+    public async Task ShouldRespondAsync_JsonWrappedInMarkdownCodeFence_ParsesCorrectly()
+    {
+        // Observed in production: models (despite schema constraints) frequently wrap their
+        // response in ```json … ``` fences. The first parse fails on the leading backtick,
+        // and JsonRepair also chokes on it — so the decision service must strip fences itself.
+        var self = MakeParticipant("Vlad");
+        var senderId = Guid.NewGuid();
+        var participants = new List<GenerationParticipant>
+        {
+            self,
+            new() { Id = senderId, Name = "User", IsUser = true },
+        };
+        var history = new List<ChatMessage>
+        {
+            new() { MessageId = 1, SenderId = senderId, SenderType = "user", Content = "Hello." }
+        };
+
+        var fenced = "```json\n{\"reason\": \"Natural opening.\", \"respond\": true, \"instruction\": \"Greet back.\"}\n```";
+
+        var service = MakeService(EndpointReturningJson(fenced));
+        var result = await service.ShouldRespondAsync(self, history, participants, 0, null, CancellationToken.None);
+
+        Assert.True(result.Respond);
+        Assert.Equal("Greet back.", result.Instruction);
+        Assert.False(result.Reason.StartsWith("Fallback"), "Expected fence-stripped JSON to parse, not the fail-closed fallback");
+    }
+
+    [Fact]
+    public async Task ShouldRespondAsync_JsonWithRawNewlinesInsideStringValue_ParsesCorrectly()
+    {
+        // Second observed failure mode: LLMs emit literal newlines inside a multi-line `reason`
+        // field. JsonRepairSharp does not escape these — the service must normalize control
+        // chars inside string values before handing off to the parser.
+        var self = MakeParticipant("Vlad");
+        var senderId = Guid.NewGuid();
+        var participants = new List<GenerationParticipant>
+        {
+            self,
+            new() { Id = senderId, Name = "User", IsUser = true },
+        };
+        var history = new List<ChatMessage>
+        {
+            new() { MessageId = 1, SenderId = senderId, SenderType = "user", Content = "Hello." }
+        };
+
+        // Raw 0x0A inside the "reason" string — exactly the byte that triggered the prod error.
+        var broken = "{\"reason\": \"First line.\nSecond line.\", \"respond\": true, \"instruction\": \"Reply.\"}";
+
+        var service = MakeService(EndpointReturningJson(broken));
+        var result = await service.ShouldRespondAsync(self, history, participants, 0, null, CancellationToken.None);
+
+        Assert.True(result.Respond);
+        Assert.False(result.Reason.StartsWith("Fallback"), "Expected escape-normalized JSON to parse, not the fail-closed fallback");
+    }
+
+    [Fact]
     public async Task ShouldRespondAsync_UnparseableJsonResponse_FailsClosedWithRespondFalse()
     {
         // If even JsonRepair can't recover the response, the service must fail closed:

--- a/backend-test/PersonaDecisionServiceTest.cs
+++ b/backend-test/PersonaDecisionServiceTest.cs
@@ -238,7 +238,7 @@ public class PersonaDecisionServiceTest
         };
 
         // JSON with a trailing comma — invalid syntax but repairable
-        var malformed = """{"respond": true, "instruction": "Go ahead", "reason": "natural",}""";
+        var malformed = """{"respond": true, "wouldSay": "Go ahead", "gutReaction": "natural",}""";
 
         var service = MakeService(EndpointReturningJson(malformed));
         var result = await service.ShouldRespondAsync(self, history, participants, 0, null, CancellationToken.None);
@@ -266,7 +266,7 @@ public class PersonaDecisionServiceTest
             new() { MessageId = 1, SenderId = senderId, SenderType = "user", Content = "Hello." }
         };
 
-        var fenced = "```json\n{\"reason\": \"Natural opening.\", \"respond\": true, \"instruction\": \"Greet back.\"}\n```";
+        var fenced = "```json\n{\"gutReaction\": \"Natural opening.\", \"respond\": true, \"wouldSay\": \"Greet back.\"}\n```";
 
         var service = MakeService(EndpointReturningJson(fenced));
         var result = await service.ShouldRespondAsync(self, history, participants, 0, null, CancellationToken.None);
@@ -294,8 +294,8 @@ public class PersonaDecisionServiceTest
             new() { MessageId = 1, SenderId = senderId, SenderType = "user", Content = "Hello." }
         };
 
-        // Raw 0x0A inside the "reason" string — exactly the byte that triggered the prod error.
-        var broken = "{\"reason\": \"First line.\nSecond line.\", \"respond\": true, \"instruction\": \"Reply.\"}";
+        // Raw 0x0A inside the "gutReaction" string — exactly the byte that triggered the prod error.
+        var broken = "{\"gutReaction\": \"First line.\nSecond line.\", \"respond\": true, \"wouldSay\": \"Reply.\"}";
 
         var service = MakeService(EndpointReturningJson(broken));
         var result = await service.ShouldRespondAsync(self, history, participants, 0, null, CancellationToken.None);

--- a/backend/Controllers/PartyController.cs
+++ b/backend/Controllers/PartyController.cs
@@ -446,8 +446,45 @@ public sealed class PartyController(
             return NotFound();
         }
 
-        var chatGroup = await grains.GetGrain<IPartyGrain>(id).CreateChatGroup(request.Name.Trim());
+        var chatGroup = await grains.GetGrain<IPartyGrain>(id).CreateChatGroup(request.Name.Trim(), request.Scenario);
         return CreatedAtAction(nameof(GetChatGroups), new { id }, chatGroup);
+    }
+
+    /// <summary>
+    /// Updates the free-text scenario / setting for a chat group. Used to (re)establish the
+    /// in-fiction context that personas see in their system prompt during generation.
+    /// </summary>
+    /// <param name="id">The party identifier.</param>
+    /// <param name="chatGroupId">The chat group identifier.</param>
+    /// <param name="request">Scenario update payload (null/whitespace clears the scenario).</param>
+    /// <returns>
+    /// <c>204 No Content</c> on success;
+    /// <c>400 Bad Request</c> if the chat group id is empty;
+    /// <c>404 Not Found</c> if the party does not exist.
+    /// </returns>
+    [HttpPut("{id:guid}/chat-groups/{chatGroupId:guid}/scenario")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> UpdateChatGroupScenario(
+        Guid id,
+        Guid chatGroupId,
+        [FromBody] UpdateChatGroupScenarioRequest request)
+    {
+        if (chatGroupId == Guid.Empty)
+        {
+            return BadRequest("Invalid chat group id");
+        }
+
+        var root = grains.GetGrain<IPartyRootGrain>(Guid.Empty);
+        await EnsureDefaultParty(root, id);
+        if (!await root.HasPartyId(id))
+        {
+            return NotFound();
+        }
+
+        await grains.GetGrain<IPartyGrain>(id).UpdateChatGroupScenario(chatGroupId, request.Scenario);
+        return NoContent();
     }
 
     /// <summary>

--- a/backend/Grains/ChatGroupGrain.cs
+++ b/backend/Grains/ChatGroupGrain.cs
@@ -59,6 +59,13 @@ public sealed class ChatGroupGrain(ILogger<ChatGroupGrain> logger)
     public async Task SetScenarioAsync(string? scenario)
     {
         var normalized = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim();
+        if (normalized is { Length: > ChatGroupLimits.MaxScenarioLength })
+        {
+            logger.LogWarning(
+                "Scenario length {Length} exceeded cap {Cap} for chat group {ChatGroupId}; truncating",
+                normalized.Length, ChatGroupLimits.MaxScenarioLength, this.GetPrimaryKey());
+            normalized = normalized[..ChatGroupLimits.MaxScenarioLength];
+        }
         RaiseEvent(new ChatGroupScenarioSetEvent { Scenario = normalized });
         await ConfirmEvents();
     }

--- a/backend/Grains/ChatGroupGrain.cs
+++ b/backend/Grains/ChatGroupGrain.cs
@@ -285,9 +285,12 @@ public sealed class ChatGroupGrain(ILogger<ChatGroupGrain> logger)
     public Task NotifyAllParticipantsAsync(ChatMessage triggeringMessage, CancellationToken ct = default)
     {
         var chatGroupId = this.GetPrimaryKey();
-        var participants = State.Participants.ToList();
+        // Skip IsUser participants: the user's "persona" is not an LLM-driven character,
+        // so activating its grain would (a) waste an LLM call and (b) write a hallucinated
+        // user reply into the chat history that other personas then react to.
+        var participants = State.Participants.Where(p => !p.IsUser).ToList();
 
-        logger.LogInformation("Fanning out to {Count} participants in chat group {ChatGroupId}",
+        logger.LogInformation("Fanning out to {Count} AI participants in chat group {ChatGroupId}",
             participants.Count, chatGroupId);
 
         foreach (var p in participants)

--- a/backend/Grains/ChatGroupGrain.cs
+++ b/backend/Grains/ChatGroupGrain.cs
@@ -288,7 +288,11 @@ public sealed class ChatGroupGrain(ILogger<ChatGroupGrain> logger)
         // Skip IsUser participants: the user's "persona" is not an LLM-driven character,
         // so activating its grain would (a) waste an LLM call and (b) write a hallucinated
         // user reply into the chat history that other personas then react to.
-        var participants = State.Participants.Where(p => !p.IsUser).ToList();
+        // Skip the sender persona too — re-evaluating one's own message produces a thought-log
+        // entry per turn for nothing (Vlad doesn't read Vlad's last line and decide to react).
+        var participants = State.Participants
+            .Where(p => !p.IsUser && p.Id != triggeringMessage.SenderId)
+            .ToList();
 
         logger.LogInformation("Fanning out to {Count} AI participants in chat group {ChatGroupId}",
             participants.Count, chatGroupId);

--- a/backend/Grains/ChatGroupGrain.cs
+++ b/backend/Grains/ChatGroupGrain.cs
@@ -35,12 +35,16 @@ public sealed class ChatGroupGrain(ILogger<ChatGroupGrain> logger)
             throw new InvalidOperationException(
                 $"ChatGroupGrain {this.GetPrimaryKey()} not registered in any party.");
 
-        var party = await GrainFactory.GetGrain<IPartyGrain>(partyId.Value).GetParty();
+        var partyGrain = GrainFactory.GetGrain<IPartyGrain>(partyId.Value);
+        var party = await partyGrain.GetParty();
+        var chatGroups = await partyGrain.GetChatGroups();
+        var thisChatGroup = chatGroups.FirstOrDefault(g => g.Id == this.GetPrimaryKey());
 
         RaiseEvent(new ChatGroupInitializedEvent
         {
             PartyId = partyId.Value,
-            Participants = [.. party.Participants]
+            Participants = [.. party.Participants],
+            Scenario = thisChatGroup?.Scenario
         });
         await ConfirmEvents();
 
@@ -49,6 +53,15 @@ public sealed class ChatGroupGrain(ILogger<ChatGroupGrain> logger)
     }
 
     public Task<Guid> GetPartyIdAsync() => Task.FromResult(State.PartyId);
+
+    public Task<string?> GetScenarioAsync() => Task.FromResult(State.Scenario);
+
+    public async Task SetScenarioAsync(string? scenario)
+    {
+        var normalized = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim();
+        RaiseEvent(new ChatGroupScenarioSetEvent { Scenario = normalized });
+        await ConfirmEvents();
+    }
 
     public Task<IReadOnlyList<ChatMessage>> GetMessagesAsync()
         => Task.FromResult<IReadOnlyList<ChatMessage>>(State.Messages.OrderBy(m => m.MessageId).ToList());
@@ -303,6 +316,12 @@ public interface IChatGroupGrain : IGrainWithGuidKey
     [Alias("GetPartyIdAsync")]
     Task<Guid> GetPartyIdAsync();
 
+    [Alias("GetScenarioAsync")]
+    Task<string?> GetScenarioAsync();
+
+    [Alias("SetScenarioAsync")]
+    Task SetScenarioAsync(string? scenario);
+
     [Alias("GetMessagesAsync")]
     Task<IReadOnlyList<ChatMessage>> GetMessagesAsync();
 
@@ -376,16 +395,25 @@ public sealed record class ChatGroupState
     [Id(4)]
     public bool Initialized { get; set; }
 
+    [Id(5)]
+    public string? Scenario { get; set; }
+
     public void Apply(ChatGroupInitializedEvent @event)
     {
         PartyId = @event.PartyId;
         Participants = [.. @event.Participants];
+        Scenario = @event.Scenario;
         Initialized = true;
     }
 
     public void Apply(ChatGroupParticipantsSetEvent @event)
     {
         Participants = [.. @event.Participants];
+    }
+
+    public void Apply(ChatGroupScenarioSetEvent @event)
+    {
+        Scenario = @event.Scenario;
     }
 
     public void Apply(ChatGroupMessageSlotReservedEvent @event)
@@ -466,6 +494,14 @@ public sealed record class ChatGroupInitializedEvent : ChatGroupEvent
 {
     [Id(0)] public Guid PartyId { get; set; }
     [Id(2)] public List<PartyParticipant> Participants { get; set; } = [];
+    [Id(3)] public string? Scenario { get; set; }
+}
+
+/// <summary>Raised when the chat group's scenario (free-text setting/context) is set or updated.</summary>
+[GenerateSerializer, Alias(nameof(ChatGroupScenarioSetEvent))]
+public sealed record class ChatGroupScenarioSetEvent : ChatGroupEvent
+{
+    [Id(0)] public string? Scenario { get; set; }
 }
 
 /// <summary>Raised when the participant list is replaced wholesale (e.g. personas added/removed from the group).</summary>

--- a/backend/Grains/PartyGrain.cs
+++ b/backend/Grains/PartyGrain.cs
@@ -86,6 +86,11 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
 
     public async Task UpdateChatGroupScenario(Guid chatGroupId, string? scenario)
     {
+        // Guard membership before raising the event — otherwise an unknown chatGroupId
+        // would persist a no-op event and activate an orphan ChatGroupGrain.
+        if (!State.ChatGroups.Any(g => g.Id == chatGroupId))
+            return;
+
         var normalized = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim();
 
         RaiseEvent(new ChatGroupScenarioUpdatedEvent

--- a/backend/Grains/PartyGrain.cs
+++ b/backend/Grains/PartyGrain.cs
@@ -66,12 +66,21 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
 
     public async Task<ChatGroupInfo> CreateChatGroup(string name, string? scenario = null)
     {
+        var normalizedScenario = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim();
+        if (normalizedScenario is { Length: > ChatGroupLimits.MaxScenarioLength })
+        {
+            logger.LogWarning(
+                "Scenario length {Length} exceeded cap {Cap} on CreateChatGroup; truncating",
+                normalizedScenario.Length, ChatGroupLimits.MaxScenarioLength);
+            normalizedScenario = normalizedScenario[..ChatGroupLimits.MaxScenarioLength];
+        }
+
         var chatGroup = new ChatGroupInfo
         {
             Id = Guid.NewGuid(),
             Name = name,
             CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            Scenario = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim()
+            Scenario = normalizedScenario
         };
 
         RaiseEvent(new ChatGroupCreatedEvent { ChatGroup = chatGroup });

--- a/backend/Grains/PartyGrain.cs
+++ b/backend/Grains/PartyGrain.cs
@@ -64,13 +64,14 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
     public Task<List<ChatGroupInfo>> GetChatGroups()
         => Task.FromResult(State.ChatGroups.ToList());
 
-    public async Task<ChatGroupInfo> CreateChatGroup(string name)
+    public async Task<ChatGroupInfo> CreateChatGroup(string name, string? scenario = null)
     {
         var chatGroup = new ChatGroupInfo
         {
             Id = Guid.NewGuid(),
             Name = name,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Scenario = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim()
         };
 
         RaiseEvent(new ChatGroupCreatedEvent { ChatGroup = chatGroup });
@@ -81,6 +82,20 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
         await registry.RegisterChatGroup(chatGroup.Id, this.GetPrimaryKey());
 
         return chatGroup;
+    }
+
+    public async Task UpdateChatGroupScenario(Guid chatGroupId, string? scenario)
+    {
+        var normalized = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim();
+
+        RaiseEvent(new ChatGroupScenarioUpdatedEvent
+        {
+            ChatGroupId = chatGroupId,
+            Scenario = normalized
+        });
+        await ConfirmEvents();
+
+        await GrainFactory.GetGrain<IChatGroupGrain>(chatGroupId).SetScenarioAsync(normalized);
     }
 
     public async Task<List<ChatMessage>> DownloadMessages()
@@ -127,11 +142,15 @@ public interface IPartyGrain : IGrainWithGuidKey
     [Alias("SetParticipants")]
     Task SetParticipants(List<PartyParticipant> participants);
 
+    [AlwaysInterleave]
     [Alias("GetChatGroups")]
     Task<List<ChatGroupInfo>> GetChatGroups();
 
     [Alias("CreateChatGroup")]
-    Task<ChatGroupInfo> CreateChatGroup(string name);
+    Task<ChatGroupInfo> CreateChatGroup(string name, string? scenario = null);
+
+    [Alias("UpdateChatGroupScenario")]
+    Task UpdateChatGroupScenario(Guid chatGroupId, string? scenario);
 
     [Alias("DownloadMessages")]
     Task<List<ChatMessage>> DownloadMessages();
@@ -161,6 +180,13 @@ public sealed record class PartyState
     public void Apply(ChatGroupCreatedEvent @event)
     {
         ChatGroups.Add(@event.ChatGroup);
+    }
+
+    public void Apply(ChatGroupScenarioUpdatedEvent @event)
+    {
+        var idx = ChatGroups.FindIndex(g => g.Id == @event.ChatGroupId);
+        if (idx >= 0)
+            ChatGroups[idx] = ChatGroups[idx] with { Scenario = @event.Scenario };
     }
 
     public void Apply(PartySetEvent @event)
@@ -208,6 +234,16 @@ public sealed record class ChatGroupCreatedEvent : PartyEvent
 {
     [Id(0)]
     public ChatGroupInfo ChatGroup { get; set; } = new();
+}
+
+[GenerateSerializer, Alias(nameof(ChatGroupScenarioUpdatedEvent))]
+public sealed record class ChatGroupScenarioUpdatedEvent : PartyEvent
+{
+    [Id(0)]
+    public Guid ChatGroupId { get; set; }
+
+    [Id(1)]
+    public string? Scenario { get; set; }
 }
 
 [GenerateSerializer, Alias(nameof(PartyDeletedEvent))]

--- a/backend/Grains/PartyGrain.cs
+++ b/backend/Grains/PartyGrain.cs
@@ -116,9 +116,9 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
 
     public async Task CancelAllGenerations(CancellationToken ct = default)
     {
-        // TODO: filter out IsUser participants — activating user persona grains here is wasteful (harmless but unnecessary).
-        var tasks = State.Participants.Select(p =>
-            GrainFactory.GetGrain<IPersonaGrain>(p.Id).CancelGenerationAsync());
+        var tasks = State.Participants
+            .Where(p => !p.IsUser)
+            .Select(p => GrainFactory.GetGrain<IPersonaGrain>(p.Id).CancelGenerationAsync());
         await Task.WhenAll(tasks);
     }
 

--- a/backend/Grains/PartyGrain.cs
+++ b/backend/Grains/PartyGrain.cs
@@ -101,6 +101,13 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
             return;
 
         var normalized = string.IsNullOrWhiteSpace(scenario) ? null : scenario.Trim();
+        if (normalized is { Length: > ChatGroupLimits.MaxScenarioLength })
+        {
+            logger.LogWarning(
+                "Scenario length {Length} exceeded cap {Cap} on UpdateChatGroupScenario for chat group {ChatGroupId}; truncating",
+                normalized.Length, ChatGroupLimits.MaxScenarioLength, chatGroupId);
+            normalized = normalized[..ChatGroupLimits.MaxScenarioLength];
+        }
 
         RaiseEvent(new ChatGroupScenarioUpdatedEvent
         {

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -23,14 +23,16 @@ public sealed class PersonaGrain(
 {
     private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
 
-    // One CTS per chat group so concurrent NotifyMessageAsync for different groups don't
-    // cancel each other. Reentrancy made the previous single _activeCts field a race:
-    // group B's call would cancel group A's in-flight generation and mark it "cancelled".
-    private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _ctsByChatGroup = new();
+    // One CTS per *in-flight generation* (chatGroup, messageId), not per chat group.
+    // Earlier (per-chat-group) keying caused message N+1 to cancel message N's still-running
+    // decision/generation, surfacing as a phantom "cancelled" appraisal on legitimate work
+    // and an empty assistant slot for any persona slow enough to overlap a follow-up.
+    // CancelGenerationAsync still cancels every in-flight generation for this persona.
+    private readonly ConcurrentDictionary<(Guid chatGroupId, int messageId), CancellationTokenSource> _ctsByGeneration = new();
 
     public Task CancelGenerationAsync()
     {
-        foreach (var cts in _ctsByChatGroup.Values)
+        foreach (var cts in _ctsByGeneration.Values)
         {
             try { cts.Cancel(); } catch (ObjectDisposedException) { }
         }
@@ -106,25 +108,17 @@ public sealed class PersonaGrain(
         var personaId = this.GetPrimaryKey();
         var persona = state.State with { Id = personaId };
 
-        var newCts = new CancellationTokenSource();
-        _ctsByChatGroup.AddOrUpdate(
-            chatGroupId,
-            _ => newCts,
-            (_, old) =>
-            {
-                try { old.Cancel(); } catch (ObjectDisposedException) { }
-                old.Dispose();
-                return newCts;
-            });
-
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, newCts.Token);
-        var linkedCt = linkedCts.Token;
-
         logger.LogInformation("Persona {PersonaName} notified of message {MessageId} in chat group {ChatGroupId}",
             persona.Name, triggeringMessage.MessageId, chatGroupId);
 
         var chatGroupGrain = GrainFactory.GetGrain<IChatGroupGrain>(chatGroupId);
         var messageId = await chatGroupGrain.GetNextMessageIdAsync(personaId);
+
+        var newCts = new CancellationTokenSource();
+        _ctsByGeneration[(chatGroupId, messageId)] = newCts;
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, newCts.Token);
+        var linkedCt = linkedCts.Token;
 
         try
         {
@@ -210,12 +204,8 @@ public sealed class PersonaGrain(
         }
         finally
         {
-            // Clear the slot only if we still own it (a later call may have replaced us).
-            if (_ctsByChatGroup.TryGetValue(chatGroupId, out var current) && ReferenceEquals(current, newCts))
-            {
-                _ctsByChatGroup.TryRemove(new KeyValuePair<Guid, CancellationTokenSource>(chatGroupId, newCts));
-                newCts.Dispose();
-            }
+            _ctsByGeneration.TryRemove(new KeyValuePair<(Guid, int), CancellationTokenSource>((chatGroupId, messageId), newCts));
+            newCts.Dispose();
         }
     }
 

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -135,7 +135,8 @@ public sealed class PersonaGrain(
                 Name = persona.Name,
                 Bio = persona.Bio,
                 SystemPrompt = persona.SystemPrompt,
-                IsUser = false
+                IsUser = false,
+                Chattiness = persona.Chattiness
             };
 
             var decisionParticipants = BuildDecisionParticipants(participants, personaId, self);
@@ -144,7 +145,7 @@ public sealed class PersonaGrain(
                 MessageStreamEvent.PersonaEvaluatingResponse, personaId.ToString(), false);
 
             var decision = await RunDecisionPhaseAsync(
-                chatGroupGrain, chatGroupId, messageId, self, history, decisionParticipants, linkedCt);
+                chatGroupGrain, chatGroupId, messageId, self, history, decisionParticipants, scenario, linkedCt);
 
             if (!decision.Respond)
             {
@@ -253,6 +254,7 @@ public sealed class PersonaGrain(
         GenerationParticipant self,
         IReadOnlyList<ChatMessage> history,
         IReadOnlyList<GenerationParticipant> participants,
+        string? scenario,
         CancellationToken ct)
     {
         var router = GrainFactory.GetGrain<ILlmRouterGrain>(0);
@@ -265,7 +267,8 @@ public sealed class PersonaGrain(
             participants,
             totalAiRounds,
             onEvent: (eventType, data, done) => NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId, eventType, data, done),
-            cancellationToken: ct);
+            cancellationToken: ct,
+            scenario: scenario);
     }
 
     private async Task<GenerationResult> RunGenerationPhaseAsync(

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -108,10 +108,42 @@ public sealed class PersonaGrain(
         var personaId = this.GetPrimaryKey();
         var persona = state.State with { Id = personaId };
 
+        // Defense-in-depth: also drop self-fan-out here. ChatGroupGrain filters first,
+        // but a stray direct-call shouldn't make Vlad ruminate on Vlad's last line.
+        if (triggeringMessage.SenderId == personaId)
+            return;
+
         logger.LogInformation("Persona {PersonaName} notified of message {MessageId} in chat group {ChatGroupId}",
             persona.Name, triggeringMessage.MessageId, chatGroupId);
 
         var chatGroupGrain = GrainFactory.GetGrain<IChatGroupGrain>(chatGroupId);
+
+        // Pre-gate: snapshot history before reserving a slot so an obvious-skip persona
+        // leaves no trace in the chat (no message slot → no thought-log entry → no LLM call).
+        // Reading int.MaxValue gives us the full current history without claiming a slot.
+        var preHistory = await chatGroupGrain.GetMessagesUntilAsync(int.MaxValue);
+        var preRounds = await chatGroupGrain.CountTrailingAssistantMessagesAsync();
+
+        var self = new GenerationParticipant
+        {
+            Id = personaId,
+            Name = persona.Name,
+            Bio = persona.Bio,
+            SystemPrompt = persona.SystemPrompt,
+            IsUser = false,
+            Chattiness = persona.Chattiness
+        };
+
+        var preUrge = PersonaDecisionService.CalculateResponseUrge(self, preHistory, preRounds);
+        var preRecentSelf = PersonaDecisionService.CountRecentSelfMessages(preHistory, personaId);
+        if (PersonaDecisionService.IsObviousSkip(preUrge, preRounds, preRecentSelf))
+        {
+            logger.LogDebug(
+                "Persona {PersonaName} silently skipped (urge={Urge:F2}, rounds={Rounds}, recentSelf={Self})",
+                persona.Name, preUrge.Total, preRounds, preRecentSelf);
+            return;
+        }
+
         var messageId = await chatGroupGrain.GetNextMessageIdAsync(personaId);
 
         var newCts = new CancellationTokenSource();
@@ -128,16 +160,6 @@ public sealed class PersonaGrain(
             var history = await chatGroupGrain.GetMessagesUntilAsync(messageId);
             var participants = await chatGroupGrain.GetParticipantsAsync();
             var scenario = await chatGroupGrain.GetScenarioAsync();
-
-            var self = new GenerationParticipant
-            {
-                Id = personaId,
-                Name = persona.Name,
-                Bio = persona.Bio,
-                SystemPrompt = persona.SystemPrompt,
-                IsUser = false,
-                Chattiness = persona.Chattiness
-            };
 
             var decisionParticipants = BuildDecisionParticipants(participants, personaId, self);
 

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -32,7 +32,7 @@ public sealed class PersonaGrain(
     {
         foreach (var cts in _ctsByChatGroup.Values)
         {
-            try { cts.Cancel(); } catch { /* already disposed */ }
+            try { cts.Cancel(); } catch (ObjectDisposedException) { }
         }
         return Task.CompletedTask;
     }
@@ -112,7 +112,7 @@ public sealed class PersonaGrain(
             _ => newCts,
             (_, old) =>
             {
-                try { old.Cancel(); } catch { }
+                try { old.Cancel(); } catch (ObjectDisposedException) { }
                 old.Dispose();
                 return newCts;
             });

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Orleans.Concurrency;
 using PartyTown.Grains.Generation;
@@ -20,14 +21,21 @@ public sealed class PersonaGrain(
     ILogger<PersonaGrain> logger)
     : Grain, IPersonaGrain
 {
-    private CancellationTokenSource? _activeCts;
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+
+    // One CTS per chat group so concurrent NotifyMessageAsync for different groups don't
+    // cancel each other. Reentrancy made the previous single _activeCts field a race:
+    // group B's call would cancel group A's in-flight generation and mark it "cancelled".
+    private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _ctsByChatGroup = new();
 
     public Task CancelGenerationAsync()
     {
-        _activeCts?.Cancel();
+        foreach (var cts in _ctsByChatGroup.Values)
+        {
+            try { cts.Cancel(); } catch { /* already disposed */ }
+        }
         return Task.CompletedTask;
     }
-    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
 
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
@@ -97,26 +105,33 @@ public sealed class PersonaGrain(
     {
         var personaId = this.GetPrimaryKey();
         var persona = state.State with { Id = personaId };
-        _activeCts?.Cancel();
-        _activeCts = new CancellationTokenSource();
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _activeCts.Token);
-        CancellationToken linkedCt = linkedCts.Token;
+
+        var newCts = new CancellationTokenSource();
+        _ctsByChatGroup.AddOrUpdate(
+            chatGroupId,
+            _ => newCts,
+            (_, old) =>
+            {
+                try { old.Cancel(); } catch { }
+                old.Dispose();
+                return newCts;
+            });
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, newCts.Token);
+        var linkedCt = linkedCts.Token;
 
         logger.LogInformation("Persona {PersonaName} notified of message {MessageId} in chat group {ChatGroupId}",
             persona.Name, triggeringMessage.MessageId, chatGroupId);
 
         var chatGroupGrain = GrainFactory.GetGrain<IChatGroupGrain>(chatGroupId);
-
-        // Phase 1: Reserve a message slot early so we can stream decision events
         var messageId = await chatGroupGrain.GetNextMessageIdAsync(personaId);
 
         try
         {
-            // Resolve the LLM endpoint
-            var router = GrainFactory.GetGrain<ILlmRouterGrain>(0);
-
-            // Fetch context from the chat group
-            var history = await chatGroupGrain.GetMessagesUntilAsync(triggeringMessage.MessageId + 1);
+            // Single history snapshot, shared by decision + generation (issue #4).
+            // Taking the snapshot at `messageId` includes any messages other personas
+            // committed between our slot reservation and our read.
+            var history = await chatGroupGrain.GetMessagesUntilAsync(messageId);
             var participants = await chatGroupGrain.GetParticipantsAsync();
 
             var self = new GenerationParticipant
@@ -128,145 +143,45 @@ public sealed class PersonaGrain(
                 IsUser = false
             };
 
-            var allParticipants = participants.Select(p =>
-            {
-                if (p.Id == personaId)
-                    return self;
-                return new GenerationParticipant
-                {
-                    Id = p.Id,
-                    Name = p.Name,
-                    IsUser = p.IsUser,
-                    Bio = null,
-                    SystemPrompt = null
-                };
-            }).ToList();
+            var decisionParticipants = BuildDecisionParticipants(participants, personaId, self);
 
-            // Send attend event so frontend knows this persona is evaluating the conversation
-            await chatGroupGrain.NotifyStreamChunkAsync(messageId, new MessageStreamEvent
-            {
-                ChatGroupId = chatGroupId,
-                Event = MessageStreamEvent.PersonaEvaluatingResponse,
-                Data = personaId.ToString(),
-                Done = false
-            });
+            await NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId,
+                MessageStreamEvent.PersonaEvaluatingResponse, personaId.ToString(), false);
 
-            // Phase 2: Decide whether to respond (streaming decision reasoning)
-            var decisionService = new PersonaDecisionService(router, loggerFactory.CreateLogger<PersonaDecisionService>());
-            var totalAiRounds = await chatGroupGrain.CountTrailingAssistantMessagesAsync();
-
-            var decision = await decisionService.ShouldRespondAsync(
-                self,
-                history,
-                allParticipants,
-                totalAiRounds,
-                onEvent: async (eventType, data, done) =>
-                {
-                    await chatGroupGrain.NotifyStreamChunkAsync(messageId, new MessageStreamEvent
-                    {
-                        ChatGroupId = chatGroupId,
-                        Event = eventType,
-                        Data = data,
-                        Done = done
-                    });
-                },
-                cancellationToken: linkedCt);
+            var decision = await RunDecisionPhaseAsync(
+                chatGroupGrain, chatGroupId, messageId, self, history, decisionParticipants, linkedCt);
 
             if (!decision.Respond)
             {
                 logger.LogInformation("Persona {PersonaName} decided NOT to respond: {Reason}", persona.Name, decision.Reason);
-
-                // Make known that we didn't care to respond and why.
                 await chatGroupGrain.MarkGenerationStoppedAsync(messageId, decision.Reason);
-
-                // Notify frontend that this persona declined
-                await chatGroupGrain.NotifyStreamChunkAsync(messageId, new MessageStreamEvent
-                {
-                    ChatGroupId = chatGroupId,
-                    Event = MessageStreamEvent.PersonaDeclinedResponse,
-                    Data = JsonSerializer.Serialize(new
-                    {
-                        personaId = personaId,
-                        reason = decision.Reason
-                    }, WebOptions),
-                    Done = true
-                });
+                await NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId,
+                    MessageStreamEvent.PersonaDeclinedResponse,
+                    JsonSerializer.Serialize(new { personaId, reason = decision.Reason }, WebOptions),
+                    true);
                 return;
             }
 
             logger.LogInformation("Persona {PersonaName} decided to respond: {Reason}", persona.Name, decision.Reason);
 
-            // Send appraisal complete — persona has decided to engage
-            await chatGroupGrain.NotifyStreamChunkAsync(messageId, new MessageStreamEvent
-            {
-                ChatGroupId = chatGroupId,
-                Event = MessageStreamEvent.PersonaEvaluationComplete,
-                Data = JsonSerializer.Serialize(new
+            await NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId,
+                MessageStreamEvent.PersonaEvaluationComplete,
+                JsonSerializer.Serialize(new
                 {
-                    personaId = personaId,
+                    personaId,
                     instruction = decision.Instruction,
                     reason = decision.Reason,
                     stop = false
                 }, WebOptions),
-                Done = false
-            });
+                false);
 
-            // Phase 3: Generate response
-            var session = new GenerationSession(router, allParticipants);
+            var fullParticipants = await BuildGenerationParticipantsAsync(participants, personaId);
+            var result = await RunGenerationPhaseAsync(
+                chatGroupGrain, chatGroupId, messageId, self, fullParticipants, history, decision.Instruction, persona.Name, linkedCt);
 
-            // Re-fetch history up to our reserved message
-            var generationHistory = await chatGroupGrain.GetMessagesUntilAsync(messageId);
-
-            // Build generation participants with full details
-            var personaRoot = GrainFactory.GetGrain<IPersonaRootGrain>(Guid.Empty);
-            var allPersonas = await personaRoot.GetAll();
-            var personaMap = allPersonas.ToDictionary(p => p.Id, p => p);
-
-            var fullParticipants = participants.Select(p =>
-            {
-                if (p.IsUser)
-                    return new GenerationParticipant { Id = p.Id, Name = p.Name, IsUser = true, SystemPrompt = "this is a real human user", Bio = null };
-                if (personaMap.TryGetValue(p.Id, out var pm))
-                    return new GenerationParticipant { Id = pm.Id, Name = pm.Name, Bio = pm.Bio, SystemPrompt = pm.SystemPrompt, IsUser = false };
-                return new GenerationParticipant { Id = p.Id, Name = p.Name, IsUser = false };
-            }).ToList();
-
-            // Generate response — appraisal already decided to engage
-            // Retry up to 2 times on transient errors (e.g. provider unavailable mid-stream)
-            const int maxRetries = 2;
-            GenerationResult result = null!;
-            for (var attempt = 0; attempt <= maxRetries; attempt++)
-            {
-                try
-                {
-                    result = await session.GenerateResponseOnlyAsync(
-                        self,
-                        generationHistory,
-                        onEvent: async (eventType, data, done) =>
-                        {
-                            await chatGroupGrain.NotifyStreamChunkAsync(messageId, new MessageStreamEvent
-                            {
-                                ChatGroupId = chatGroupId,
-                                Event = eventType,
-                                Data = data,
-                                Done = done
-                            });
-                        },
-                        linkedCt);
-                    break; // success
-                }
-                catch (OperationCanceledException) { throw; } // manual cancel — don't retry
-                catch (Exception ex) when (attempt < maxRetries)
-                {
-                    logger.LogWarning(ex, "Persona {PersonaName} generation attempt {Attempt} failed, retrying", persona.Name, attempt + 1);
-                    await Task.Delay(TimeSpan.FromSeconds(2 * (attempt + 1)), linkedCt);
-                }
-            }
-
-            // Phase 4: Store the completed response
             var appraisalJson = JsonSerializer.Serialize(new
             {
-                personaId = personaId,
+                personaId,
                 instruction = decision.Instruction,
                 reason = decision.Reason,
                 stop = false
@@ -292,7 +207,138 @@ public sealed class PersonaGrain(
             // FIXME: If at some point we go public, don't send exceptions over the wire
             await chatGroupGrain.MarkGenerationFailedAsync(messageId, ex.ToString());
         }
+        finally
+        {
+            // Clear the slot only if we still own it (a later call may have replaced us).
+            if (_ctsByChatGroup.TryGetValue(chatGroupId, out var current) && ReferenceEquals(current, newCts))
+            {
+                _ctsByChatGroup.TryRemove(new KeyValuePair<Guid, CancellationTokenSource>(chatGroupId, newCts));
+                newCts.Dispose();
+            }
+        }
     }
+
+    private static List<GenerationParticipant> BuildDecisionParticipants(
+        IReadOnlyList<PartyParticipant> participants,
+        Guid personaId,
+        GenerationParticipant self)
+        => participants.Select(p => p.Id == personaId
+            ? self
+            : new GenerationParticipant
+            {
+                Id = p.Id,
+                Name = p.Name,
+                IsUser = p.IsUser,
+                Bio = null,
+                SystemPrompt = null
+            }).ToList();
+
+    private async Task<List<GenerationParticipant>> BuildGenerationParticipantsAsync(
+        IReadOnlyList<PartyParticipant> participants,
+        Guid personaId)
+    {
+        var personaRoot = GrainFactory.GetGrain<IPersonaRootGrain>(Guid.Empty);
+        var allPersonas = await personaRoot.GetAll();
+        var personaMap = allPersonas.ToDictionary(p => p.Id, p => p);
+
+        return participants.Select(p =>
+        {
+            if (p.IsUser)
+            {
+                // SystemPrompt left null for users: IsUser carries the distinction, and a literal
+                // marker string risked leaking into concatenated prompts downstream (issue #9).
+                return new GenerationParticipant { Id = p.Id, Name = p.Name, IsUser = true, SystemPrompt = null, Bio = null };
+            }
+            if (personaMap.TryGetValue(p.Id, out var pm))
+                return new GenerationParticipant { Id = pm.Id, Name = pm.Name, Bio = pm.Bio, SystemPrompt = pm.SystemPrompt, IsUser = false };
+            return new GenerationParticipant { Id = p.Id, Name = p.Name, IsUser = false };
+        }).ToList();
+    }
+
+    private async Task<ShouldRespondResult> RunDecisionPhaseAsync(
+        IChatGroupGrain chatGroupGrain,
+        Guid chatGroupId,
+        int messageId,
+        GenerationParticipant self,
+        IReadOnlyList<ChatMessage> history,
+        IReadOnlyList<GenerationParticipant> participants,
+        CancellationToken ct)
+    {
+        var router = GrainFactory.GetGrain<ILlmRouterGrain>(0);
+        var decisionService = new PersonaDecisionService(router, loggerFactory.CreateLogger<PersonaDecisionService>());
+        var totalAiRounds = await chatGroupGrain.CountTrailingAssistantMessagesAsync();
+
+        return await decisionService.ShouldRespondAsync(
+            self,
+            history,
+            participants,
+            totalAiRounds,
+            onEvent: (eventType, data, done) => NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId, eventType, data, done),
+            cancellationToken: ct);
+    }
+
+    private async Task<GenerationResult> RunGenerationPhaseAsync(
+        IChatGroupGrain chatGroupGrain,
+        Guid chatGroupId,
+        int messageId,
+        GenerationParticipant self,
+        List<GenerationParticipant> fullParticipants,
+        IReadOnlyList<ChatMessage> history,
+        string? turnInstruction,
+        string personaName,
+        CancellationToken ct)
+    {
+        var router = GrainFactory.GetGrain<ILlmRouterGrain>(0);
+        var session = new GenerationSession(router, fullParticipants);
+
+        const int maxRetries = 2;
+        GenerationResult? result = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                result = await session.GenerateResponseOnlyAsync(
+                    self,
+                    history,
+                    onEvent: (eventType, data, done) => NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId, eventType, data, done),
+                    ct,
+                    turnInstruction);
+                break;
+            }
+            catch (OperationCanceledException)
+            {
+                throw; // manual cancel — don't retry, don't emit retry event
+            }
+            catch (Exception ex) when (attempt < maxRetries)
+            {
+                logger.LogWarning(ex, "Persona {PersonaName} generation attempt {Attempt} failed, retrying", personaName, attempt + 1);
+                // Tell the frontend to clear any partial chunks it buffered during this attempt
+                // before the next attempt begins restreaming from scratch (issue #8).
+                await NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId,
+                    MessageStreamEvent.GenerationRetry,
+                    JsonSerializer.Serialize(new { attempt = attempt + 1, nextAttemptInSeconds = 2 * (attempt + 1) }, WebOptions),
+                    false);
+                await Task.Delay(TimeSpan.FromSeconds(2 * (attempt + 1)), ct);
+            }
+        }
+
+        return result!;
+    }
+
+    private static Task NotifyStreamAsync(
+        IChatGroupGrain chatGroupGrain,
+        Guid chatGroupId,
+        int messageId,
+        string eventType,
+        string data,
+        bool done)
+        => chatGroupGrain.NotifyStreamChunkAsync(messageId, new MessageStreamEvent
+        {
+            ChatGroupId = chatGroupId,
+            Event = eventType,
+            Data = data,
+            Done = done
+        });
 
     private async Task UpdateStateAsync(Func<Persona, Persona> update)
     {

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -133,6 +133,7 @@ public sealed class PersonaGrain(
             // committed between our slot reservation and our read.
             var history = await chatGroupGrain.GetMessagesUntilAsync(messageId);
             var participants = await chatGroupGrain.GetParticipantsAsync();
+            var scenario = await chatGroupGrain.GetScenarioAsync();
 
             var self = new GenerationParticipant
             {
@@ -177,7 +178,7 @@ public sealed class PersonaGrain(
 
             var fullParticipants = await BuildGenerationParticipantsAsync(participants, personaId);
             var result = await RunGenerationPhaseAsync(
-                chatGroupGrain, chatGroupId, messageId, self, fullParticipants, history, decision.Instruction, persona.Name, linkedCt);
+                chatGroupGrain, chatGroupId, messageId, self, fullParticipants, history, decision.Instruction, scenario, persona.Name, linkedCt);
 
             var appraisalJson = JsonSerializer.Serialize(new
             {
@@ -285,6 +286,7 @@ public sealed class PersonaGrain(
         List<GenerationParticipant> fullParticipants,
         IReadOnlyList<ChatMessage> history,
         string? turnInstruction,
+        string? scenario,
         string personaName,
         CancellationToken ct)
     {
@@ -302,7 +304,8 @@ public sealed class PersonaGrain(
                     history,
                     onEvent: (eventType, data, done) => NotifyStreamAsync(chatGroupGrain, chatGroupId, messageId, eventType, data, done),
                     ct,
-                    turnInstruction);
+                    turnInstruction,
+                    scenario);
                 break;
             }
             catch (OperationCanceledException)

--- a/backend/Model/Party.cs
+++ b/backend/Model/Party.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace PartyTown.Model;
 
 // Domain terminology:
@@ -50,12 +52,20 @@ public sealed record class ChatGroupInfo
 public sealed record class CreateChatGroupRequest
 {
     public string Name { get; set; } = string.Empty;
+
+    [MaxLength(ChatGroupLimits.MaxScenarioLength)]
     public string? Scenario { get; set; }
 }
 
 public sealed record class UpdateChatGroupScenarioRequest
 {
+    [MaxLength(ChatGroupLimits.MaxScenarioLength)]
     public string? Scenario { get; set; }
+}
+
+public static class ChatGroupLimits
+{
+    public const int MaxScenarioLength = 2000;
 }
 
 public sealed record class CreatePartyRequest

--- a/backend/Model/Party.cs
+++ b/backend/Model/Party.cs
@@ -42,11 +42,20 @@ public sealed record class ChatGroupInfo
 
     [Id(2)]
     public long CreatedAt { get; set; }
+
+    [Id(3)]
+    public string? Scenario { get; set; }
 }
 
 public sealed record class CreateChatGroupRequest
 {
     public string Name { get; set; } = string.Empty;
+    public string? Scenario { get; set; }
+}
+
+public sealed record class UpdateChatGroupScenarioRequest
+{
+    public string? Scenario { get; set; }
 }
 
 public sealed record class CreatePartyRequest

--- a/backend/Model/Persona.cs
+++ b/backend/Model/Persona.cs
@@ -31,15 +31,24 @@ public sealed record class Persona : PersonaMetadata
     [Id(3)]
     public string? Bio { get; set; }
 
+    /// <summary>
+    /// 0..1 dial mixed into the chaos urge component in PersonaDecisionService.
+    /// 0 = brooding, only speaks when pulled; 1 = always wants to chime in.
+    /// Default 0.5 keeps existing personas behaviorally neutral on first run.
+    /// </summary>
+    [Id(4)]
+    public double Chattiness { get; set; } = 0.5;
+
     public Persona()
     {
     }
 
-    public Persona(Guid id, string name, string systemPrompt, string? bio)
+    public Persona(Guid id, string name, string systemPrompt, string? bio, double chattiness = 0.5)
         : base(id, name)
     {
         SystemPrompt = systemPrompt;
         Bio = bio;
+        Chattiness = chattiness;
     }
 }
 

--- a/backend/Services/Generation/ChatMessageRenderer.cs
+++ b/backend/Services/Generation/ChatMessageRenderer.cs
@@ -1,0 +1,19 @@
+using System.Security;
+using PartyTown.Model;
+
+namespace PartyTown.Services.Generation;
+
+/// <summary>
+/// Shared XML rendering for chat messages handed to the LLM. Both decision and generation
+/// prompts render history through this so the model sees one consistent schema.
+///
+/// NOTE: SecurityElement.Escape handles XML syntax characters only. It is NOT a prompt-injection
+/// defense — message content must be treated as untrusted input to the model. If personas gain
+/// real capabilities (tool calls, file writes, privileged retrieval), add a moderation pass
+/// upstream instead of relying on escaping here.
+/// </summary>
+internal static class ChatMessageRenderer
+{
+    public static string Render(ChatMessage message, string senderName)
+        => $"<message sender=\"{SecurityElement.Escape(senderName)}\" senderId=\"{message.SenderId}\">\n{SecurityElement.Escape(message.Content ?? "")}\n</message>";
+}

--- a/backend/Services/Generation/GenerationSession.cs
+++ b/backend/Services/Generation/GenerationSession.cs
@@ -1,4 +1,3 @@
-using System.Security;
 using System.Text;
 using PartyTown.Grains.Generation;
 using PartyTown.Model;
@@ -15,7 +14,8 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
         GenerationParticipant persona,
         IReadOnlyList<ChatMessage> history,
         Func<string, string, bool, Task> onEvent,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? turnInstruction = null)
     {
         var others = allParticipants.Where(p => p.Id != persona.Id).ToList();
         var messages = new List<LlmChatMessage>
@@ -23,17 +23,7 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
             new()
             {
                 Role = "system",
-                Content = Instruction(
-                    """
-                    The headquarters of a stealth software startup producing a mobile app for
-                    the horticulture industry.
-                    'Stealth' meaning the company operates discreetly and does not reveal its
-                    existence until ready to launch; this in order to protect the revolutionary
-                    tech. At least, this is what employees are told, or is there more to it?
-                    """,
-                    persona.SystemPrompt ?? string.Empty,
-                    persona,
-                    others),
+                Content = Instruction(persona.SystemPrompt ?? string.Empty, persona, others),
                 Name = persona.Id.ToString()
             }
         };
@@ -43,11 +33,22 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
             Role = message.SenderId == persona.Id ? "assistant" : "user",
             Content = message.SenderId == persona.Id
                 ? (message.Content ?? string.Empty)
-                : ToUserScopedMessage(
+                : ChatMessageRenderer.Render(
                     message,
                     allParticipants.FirstOrDefault(p => p.Id == message.SenderId)?.Name ?? "Unknown"),
             Name = message.SenderId.ToString()
         }));
+
+        // Recency-position nudge from the decision step, if present.
+        if (!string.IsNullOrWhiteSpace(turnInstruction))
+        {
+            messages.Add(new LlmChatMessage
+            {
+                Role = "system",
+                Content = $"Guidance for this turn: {turnInstruction}",
+                Name = persona.Id.ToString()
+            });
+        }
 
         var builder = new StringBuilder();
         var reasoning = new StringBuilder();
@@ -83,19 +84,27 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
         };
     }
 
-    private static string ToUserScopedMessage(ChatMessage message, string senderName)
-        => $"<message sender=\"{SecurityElement.Escape(senderName)}\" senderId=\"{message.SenderId}\">\n{SecurityElement.Escape(message.Content ?? "")}\n</message>";
-
-    private static string Instruction(string scenario, string personaPrompt, GenerationParticipant self, List<GenerationParticipant> others)
+    private static string Instruction(string personaPrompt, GenerationParticipant self, List<GenerationParticipant> others)
     {
         var othersSection = others.Count == 0
             ? "(no other participants)"
-            : string.Join("\n", others.Select(p => $"- {p.Name}: {p.Bio ?? "No bio available"}"));
+            : string.Join("\n", others.Select(p =>
+                p.IsUser
+                    ? $"- {p.Name} (human)"
+                    : $"- {p.Name}: {p.Bio ?? "No bio available"}"));
 
+        // Persona identity block claims the primacy position; chat-style rules land after,
+        // so the model sees who it is before it sees generic etiquette.
         return $"""
-# Instruction
-You are in a (group) chat with other people. Stay completely in character
-as your persona — never acknowledge that you are an AI or playing a role.
+# You are: {self.Name} (ID: {self.Id})
+{personaPrompt}
+
+# Other participants
+{othersSection}
+
+# Style
+You are in a (group) chat with other people. Stay completely in character as
+your persona — never acknowledge that you are an AI or playing a role.
 
 Talk like a real person in a casual group chat: short, reactive, and natural.
 Actually respond to what others just said — agree, disagree, interrupt, joke,
@@ -106,15 +115,6 @@ Only go longer if you're genuinely explaining something or telling a story.
 
 You can use *italics* sparingly for brief actions or reactions (e.g. *sighs*,
 *leans back*), but don't narrate elaborate scenes or stage directions.
-
-# You are: {self.Name} (ID: {self.Id})
-{personaPrompt}
-
-# Other participants
-{othersSection}
-
-# Scenario
-{scenario}
 """;
     }
 }

--- a/backend/Services/Generation/GenerationSession.cs
+++ b/backend/Services/Generation/GenerationSession.cs
@@ -15,7 +15,8 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
         IReadOnlyList<ChatMessage> history,
         Func<string, string, bool, Task> onEvent,
         CancellationToken cancellationToken,
-        string? turnInstruction = null)
+        string? turnInstruction = null,
+        string? scenario = null)
     {
         var others = allParticipants.Where(p => p.Id != persona.Id).ToList();
         var messages = new List<LlmChatMessage>
@@ -23,7 +24,7 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
             new()
             {
                 Role = "system",
-                Content = Instruction(persona.SystemPrompt ?? string.Empty, persona, others),
+                Content = Instruction(persona.SystemPrompt ?? string.Empty, persona, others, scenario),
                 Name = persona.Id.ToString()
             }
         };
@@ -84,7 +85,7 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
         };
     }
 
-    private static string Instruction(string personaPrompt, GenerationParticipant self, List<GenerationParticipant> others)
+    private static string Instruction(string personaPrompt, GenerationParticipant self, List<GenerationParticipant> others, string? scenario)
     {
         var othersSection = others.Count == 0
             ? "(no other participants)"
@@ -93,12 +94,18 @@ public sealed class GenerationSession(ILlmRouterGrain router, List<GenerationPar
                     ? $"- {p.Name} (human)"
                     : $"- {p.Name}: {p.Bio ?? "No bio available"}"));
 
+        // Scenario sits between identity and the participant roster: persona-self comes first
+        // (primacy), the in-fiction setting establishes context, then who else is there.
+        var scenarioSection = string.IsNullOrWhiteSpace(scenario)
+            ? string.Empty
+            : $"\n# Scenario\n{scenario.Trim()}\n";
+
         // Persona identity block claims the primacy position; chat-style rules land after,
         // so the model sees who it is before it sees generic etiquette.
         return $"""
 # You are: {self.Name} (ID: {self.Id})
 {personaPrompt}
-
+{scenarioSection}
 # Other participants
 {othersSection}
 

--- a/backend/Services/Generation/GenerationSession.cs
+++ b/backend/Services/Generation/GenerationSession.cs
@@ -133,6 +133,10 @@ public sealed record class GenerationParticipant
     public string? Bio { get; init; }
     public string? SystemPrompt { get; init; }
     public bool IsUser { get; init; }
+
+    /// <summary>0..1 dial controlling urge to chime in. Drives chaos-bonus weighting in
+    /// PersonaDecisionService. Defaults to 0.5 for users / unset personas.</summary>
+    public double Chattiness { get; init; } = 0.5;
 }
 
 public sealed record class GenerationResult

--- a/backend/Services/Generation/PersonaDecisionService.cs
+++ b/backend/Services/Generation/PersonaDecisionService.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using JsonRepairSharp;
 using PartyTown.Grains.Generation;
@@ -11,15 +12,23 @@ namespace PartyTown.Services.Generation;
 
 /// <summary>
 /// Per-persona decision service: each persona independently decides whether to respond.
-/// Replaces the global Overseer with a self-referential "should I speak?" LLM call.
+///
+/// Two axes are kept distinct:
+///   • Frequency control — how often a persona speaks (round penalty, self-dominance,
+///     chattiness-weighted chaos). Stays mathematical, prevents spam.
+///   • Engagement register — when the persona DOES engage, the prompt asks them to
+///     react in-character first ("gut reaction"), then judge whether it's worth airtime.
+///     This stops the "no signal / no clear prompt" assistant-restraint failure mode where
+///     personas decline cold-open user messages with bureaucratic justifications.
 /// </summary>
 public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logger)
 {
     private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// Calculates a response urge score (0.0 - 1.0) based on mention detection,
-    /// silence streak, and question presence. Used to auto-respond or add pressure.
+    /// Calculates a response urge score (0.0 - 1.0) from mention detection, silence streak,
+    /// question presence, cold-open (fresh user message into a quiet room), and chattiness-
+    /// weighted chaos.
     /// </summary>
     public static ResponseUrge CalculateResponseUrge(
         GenerationParticipant self,
@@ -29,9 +38,10 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         double mentionScore = 0;
         double questionScore = 0;
         double silenceStreakScore = 0;
+        double coldOpenScore = 0;
 
         if (history.Count == 0)
-            return new ResponseUrge(0, 0, 0, 0, Random.Shared.NextDouble());
+            return new ResponseUrge(0, 0, 0, 0, 0, Random.Shared.NextDouble() * self.Chattiness);
 
         var latest = history[^1];
         var content = latest.Content ?? "";
@@ -55,13 +65,24 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         // Each round without a response increases urge slightly
         silenceStreakScore = Math.Min(0.4, totalAiRoundsInGroup * 0.1);
 
-        var chaosScore = Random.Shared.NextDouble();
-        var total = Math.Min(1.0, mentionScore + questionScore + silenceStreakScore);
-        return new ResponseUrge(total, mentionScore, questionScore, silenceStreakScore, chaosScore);
+        // Cold-open: a fresh user message landing in a quiet room (no AI activity yet).
+        // Without this floor, "hiya" yields urge≈0 and every persona declines with a
+        // politeness-flavoured justification. A bar with a new arrival should produce
+        // at least one reaction.
+        if (latest.SenderType == "user" && totalAiRoundsInGroup == 0)
+            coldOpenScore = 0.5;
+
+        // Chaos weighted by per-persona chattiness. Replaces pure random with
+        // character-driven variability — a chatty Denise pings more than a brooding Vlad.
+        var chaosScore = Random.Shared.NextDouble() * self.Chattiness;
+
+        var total = Math.Min(1.0, mentionScore + questionScore + silenceStreakScore + coldOpenScore);
+        return new ResponseUrge(total, mentionScore, questionScore, silenceStreakScore, coldOpenScore, chaosScore);
     }
 
     /// <summary>
-    /// Appraises whether the persona should respond based on the conversation history and participants.
+    /// Appraises whether the persona should respond based on the conversation history,
+    /// participants, and (optionally) the scenario the chat is set in.
     /// </summary>
     public async Task<ShouldRespondResult> ShouldRespondAsync(
         GenerationParticipant self,
@@ -69,7 +90,8 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         IReadOnlyList<GenerationParticipant> participants,
         int totalAiRoundsInGroup,
         Func<string, string, bool, Task>? onEvent,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? scenario = null)
     {
         var urge = CalculateResponseUrge(self, history, totalAiRoundsInGroup);
         var recentSelfMessageCount = CountRecentSelfMessages(history, self.Id);
@@ -87,23 +109,25 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
             return new ShouldRespondResult
             {
                 Respond = true,
-                Instruction = "You were directly addressed — respond naturally.",
-                Reason = $"Auto-respond: direct mention detected (urge={urge.Total:F2})"
+                Instruction = "React naturally — they spoke to you.",
+                Reason = $"Heard my name (urge={urge.Total:F2}). Worth a reply."
             };
         }
 
         var messages = new List<LlmChatMessage>
         {
-            new() { Role = "system", Content = ShouldRespondSystemPrompt(self, participants) },
+            new() { Role = "system", Content = ShouldRespondSystemPrompt(self, participants, scenario) },
             new() { Role = "user", Content =
                 ShouldRespondUserPrompt(recentMessages, totalAiRoundsInGroup, recentSelfMessageCount, self, urge) }
         };
 
         var text = new StringBuilder();
 
-        // Schema field order drives generation order. Reason first → the model reasons before
-        // committing to a boolean, countering the confirmation-bias pattern where an early
-        // `respond` decision is then rationalized by a post-hoc `reason`.
+        // Schema field order drives generation order. gutReaction first → the model engages
+        // in-character before judging airtime. wouldSay next — the literal text they'd type
+        // (or empty). respond derives last from whether wouldSay is non-empty. This inverts
+        // the previous reason→respond order, which encouraged the model to write a justification
+        // frame absorbing the assistant-restraint prior.
         var responseFormat = new JsonObject
         {
             ["type"] = "json_schema",
@@ -116,11 +140,11 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
                     ["type"] = "object",
                     ["properties"] = new JsonObject
                     {
-                        ["reason"] = new JsonObject { ["type"] = "string" },
-                        ["respond"] = new JsonObject { ["type"] = "boolean" },
-                        ["instruction"] = new JsonObject { ["type"] = "string" }
+                        ["gutReaction"] = new JsonObject { ["type"] = "string" },
+                        ["wouldSay"] = new JsonObject { ["type"] = "string" },
+                        ["respond"] = new JsonObject { ["type"] = "boolean" }
                     },
-                    ["required"] = new JsonArray("reason", "respond", "instruction")
+                    ["required"] = new JsonArray("gutReaction", "wouldSay", "respond")
                 }
             }
         };
@@ -148,8 +172,8 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         }
 
         var raw = text.ToString().Trim();
-        logger.LogInformation("Persona {PersonaName} response urge: total={Total:F2} mention={Mention:F2} question={Question:F2} silence={Silence:F2} chaos={Chaos:F2}",
-            self.Name, urge.Total, urge.MentionScore, urge.QuestionScore, urge.SilenceStreakScore, urge.ChaosScore);
+        logger.LogInformation("Persona {PersonaName} response urge: total={Total:F2} mention={Mention:F2} question={Question:F2} silence={Silence:F2} coldOpen={ColdOpen:F2} chaos={Chaos:F2}",
+            self.Name, urge.Total, urge.MentionScore, urge.QuestionScore, urge.SilenceStreakScore, urge.ColdOpenScore, urge.ChaosScore);
 
         ShouldRespondResult? parsed = null;
 
@@ -172,7 +196,7 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
             //   1. Strip markdown code fences (```json … ```) that some models wrap output in.
             //   2. Escape raw control chars (newline, tab, etc.) found *inside* string values —
             //      JsonRepairSharp does not handle these, but the symptom appears often enough
-            //      in multi-line `reason` fields that we fix it before handing off.
+            //      in multi-line `gutReaction` fields that we fix it before handing off.
             var cleaned = ExtractJsonPayload(raw);
 
             try
@@ -198,9 +222,20 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         parsed ??= new ShouldRespondResult
         {
             Respond = false,
-            Instruction = "Do not send a message.",
+            Instruction = string.Empty,
             Reason = "Fallback — unparseable decision"
         };
+
+        // Coherence guard: model can emit respond=true with an empty wouldSay, or vice-versa.
+        // Trust the wouldSay payload — it's the actual text the persona would utter.
+        if (parsed.Respond && string.IsNullOrWhiteSpace(parsed.Instruction))
+        {
+            parsed = parsed with { Respond = false };
+        }
+        else if (!parsed.Respond && !string.IsNullOrWhiteSpace(parsed.Instruction))
+        {
+            parsed = parsed with { Respond = true };
+        }
 
         if (!parsed.Respond && parsed.Reason.StartsWith("Fallback"))
             logger.LogDebug("Persona {PersonaName} suppressed due to unparseable decision. Raw: {Raw}", self.Name, raw);
@@ -324,36 +359,49 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         return count;
     }
 
-    private static string ShouldRespondSystemPrompt(GenerationParticipant self, IReadOnlyList<GenerationParticipant> participants)
-        => $"""
-# You are: {self.Name}
-Bio: {self.Bio ?? "No bio"}
+    private static string ShouldRespondSystemPrompt(
+        GenerationParticipant self,
+        IReadOnlyList<GenerationParticipant> participants,
+        string? scenario)
+    {
+        var scenarioBlock = string.IsNullOrWhiteSpace(scenario)
+            ? string.Empty
+            : $"\n# Setting\n{scenario.Trim()}\n";
 
-# Task
-You are deciding whether YOU should respond to the latest message in a group chat.
-You are NOT generating a response — just deciding whether to speak.
-
-# Other participants
-{string.Join("\n", participants.Where(p => p.Id != self.Id).Select(p =>
+        return $$"""
+# You are: {{self.Name}}
+{{(string.IsNullOrWhiteSpace(self.Bio) ? "(no bio)" : self.Bio)}}
+{{scenarioBlock}}
+# Other people in the room
+{{string.Join("\n", participants.Where(p => p.Id != self.Id).Select(p =>
     p.IsUser
         ? $"- {p.Name} (human)"
-        : $"- {p.Name}: {p.Bio ?? "No bio"}"))}
+        : $"- {p.Name}: {p.Bio ?? "no bio"}"))}}
 
-# How to decide
-Consider:
-- Were you directly addressed, mentioned, or asked a question?
-- Would you naturally react to what was just said, given your personality?
-- Would it be weird or forced if you jumped in right now?
-- Has someone else already said what you would say?
-- Have you been talking too much recently? Give others space.
+# What you're doing
+You're hanging out in a casual group chat. Someone just spoke. Read it
+the way YOU would — as {{self.Name}}, with your tastes, hangups, and mood.
 
-Be honest — not everyone needs to respond to everything. Silence is fine.
+First: what's your honest gut reaction? A quick thought, feeling, eye-roll,
+laugh, disagreement, "huh, interesting" — whatever actually surfaces.
+Always write this. Be specific, in your voice — not a meta-summary.
 
-# Output
-Respond with a JSON object. Reason through the decision first; the `respond` boolean
-must follow from your reasoning, not precede it. If you decide to respond, provide
-a brief instruction (one sentence) to guide your response — a natural nudge, not a script.
+Second: would you actually say something out loud right now? Speak when
+your reaction is worth airtime — when you have a take, a feeling, a quip,
+a counterpoint, a question, a "yes and." Pass when you're just nodding
+along, when someone else is mid-flow, or when you've been doing all the
+talking. Boring silence is worse than a small chime-in; constant interjection
+is worse than letting the room breathe. Use judgement.
+
+# Output (JSON)
+- gutReaction: short, in-character first thought. Always written.
+- wouldSay: what you'd actually type into the chat right now, OR ""
+  (empty string) if you'd let it pass. This becomes your message verbatim
+  if you speak — write it as the chat message itself, not as a description
+  of what you'd say.
+- respond: true iff wouldSay is non-empty.
 """;
+    }
 
     private static string ShouldRespondUserPrompt(
         IEnumerable<ChatMessageWithSenderName> messages,
@@ -389,13 +437,15 @@ a brief instruction (one sentence) to guide your response — a natural nudge, n
 
         var net = urge.Total - roundPenalty - selfPenalty + chaosBonus;
 
+        // Math nudge framed as a social cue (room-state) rather than a directive — so the
+        // model reads it as context, not as a command from the system that overrides character.
         var nudge = net switch
         {
-            >= 0.7 => "> Strong pull to speak up — lean toward responding.",
-            >= 0.4 => "> Some pull to chime in. Use your judgment.",
-            >= 0.0 => "> No strong signal either way.",
-            >= -0.4 => "> Lean toward staying quiet — give others room.",
-            _ => "> Do NOT respond unless you were directly asked a question."
+            >= 0.7 => "(Room: people are looking at you — there's space and a pull to chime in.)",
+            >= 0.4 => "(Room: there's an opening if you've got something. No pressure either way.)",
+            >= 0.0 => "(Room: chatter's flowing — speak if it's worth airtime, otherwise let it ride.)",
+            >= -0.4 => "(Room: someone else just had the floor. Lean toward letting it breathe.)",
+            _ => "(Room: you've been dominating, or it's clearly not your moment. Pass unless directly addressed.)"
         };
 
         var renderedMessages = string.Join(
@@ -408,25 +458,45 @@ a brief instruction (one sentence) to guide your response — a natural nudge, n
 
 {nudge}
 
-# Decision
-Should {self.Name} respond right now?
-JSON object with: reason (string — think first, why or why not), respond (boolean — follows from reason), instruction (string — guidance if respond=true, empty otherwise)
+# Your turn ({self.Name})
+React first (gutReaction). Then decide if it's worth saying out loud (wouldSay).
+JSON only.
 """;
     }
 }
 
-public readonly record struct ResponseUrge(double Total, double MentionScore, double QuestionScore, double SilenceStreakScore, double ChaosScore);
+public readonly record struct ResponseUrge(
+    double Total,
+    double MentionScore,
+    double QuestionScore,
+    double SilenceStreakScore,
+    double ColdOpenScore,
+    double ChaosScore);
 
 [GenerateSerializer, Alias(nameof(ShouldRespondResult))]
 public sealed record class ShouldRespondResult
 {
     [Id(0)]
+    [JsonPropertyName("respond")]
     public bool Respond { get; init; }
 
+    /// <summary>
+    /// The literal text the persona would type into the chat — empty when declining.
+    /// Serialized as "wouldSay" in the LLM-facing JSON schema; field name retained as
+    /// Instruction so the downstream <c>turnInstruction</c> seed and frontend
+    /// <c>appraisal.instruction</c> consumer keep working.
+    /// </summary>
     [Id(1)]
+    [JsonPropertyName("wouldSay")]
     public string Instruction { get; init; } = string.Empty;
 
+    /// <summary>
+    /// In-character first reaction — always written. Serialized as "gutReaction" in the
+    /// LLM-facing JSON schema; field name retained as Reason so the thought-log UI
+    /// (which reads <c>appraisal.reason</c>) keeps surfacing it without a frontend change.
+    /// </summary>
     [Id(2)]
+    [JsonPropertyName("gutReaction")]
     public string Reason { get; init; } = string.Empty;
 }
 

--- a/backend/Services/Generation/PersonaDecisionService.cs
+++ b/backend/Services/Generation/PersonaDecisionService.cs
@@ -1,7 +1,7 @@
-using System.Security;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using JsonRepairSharp;
 using PartyTown.Grains.Generation;
 using PartyTown.Model;
@@ -34,15 +34,21 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
             return new ResponseUrge(0, 0, 0, 0, Random.Shared.NextDouble());
 
         var latest = history[^1];
-        var contentLower = (latest.Content ?? "").ToLowerInvariant();
-        var nameLower = self.Name.ToLowerInvariant();
+        var content = latest.Content ?? "";
 
-        // Direct mention: is the persona's name in the latest message?
-        if (contentLower.Contains(nameLower))
-            mentionScore = 1.0;
+        // Direct mention: persona name as a whole word (case-insensitive).
+        // Substring matching triggered on "Tim" in "intimate", "optimization", etc.
+        if (!string.IsNullOrWhiteSpace(self.Name))
+        {
+            var mentionRegex = new Regex(
+                $@"\b{Regex.Escape(self.Name)}\b",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            if (mentionRegex.IsMatch(content))
+                mentionScore = 1.0;
+        }
 
         // Question detection: does the latest message end with a question mark?
-        if (ContentTrimmed(latest.Content ?? "").EndsWith('?'))
+        if (content.TrimEnd().EndsWith('?'))
             questionScore = 0.6;
 
         // Silence streak: how many AI rounds without this persona responding?
@@ -53,8 +59,6 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         var total = Math.Min(1.0, mentionScore + questionScore + silenceStreakScore);
         return new ResponseUrge(total, mentionScore, questionScore, silenceStreakScore, chaosScore);
     }
-
-    private static string ContentTrimmed(string content) => content.TrimEnd();
 
     /// <summary>
     /// Appraises whether the persona should respond based on the conversation history and participants.
@@ -97,6 +101,9 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
 
         var text = new StringBuilder();
 
+        // Schema field order drives generation order. Reason first → the model reasons before
+        // committing to a boolean, countering the confirmation-bias pattern where an early
+        // `respond` decision is then rationalized by a post-hoc `reason`.
         var responseFormat = new JsonObject
         {
             ["type"] = "json_schema",
@@ -109,11 +116,11 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
                     ["type"] = "object",
                     ["properties"] = new JsonObject
                     {
+                        ["reason"] = new JsonObject { ["type"] = "string" },
                         ["respond"] = new JsonObject { ["type"] = "boolean" },
-                        ["instruction"] = new JsonObject { ["type"] = "string" },
-                        ["reason"] = new JsonObject { ["type"] = "string" }
+                        ["instruction"] = new JsonObject { ["type"] = "string" }
                     },
-                    ["required"] = new JsonArray("respond", "instruction", "reason")
+                    ["required"] = new JsonArray("reason", "respond", "instruction")
                 }
             }
         };
@@ -206,10 +213,20 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
 
     private static string ShouldRespondSystemPrompt(GenerationParticipant self, IReadOnlyList<GenerationParticipant> participants)
         => $"""
-# Instruction
-You are {self.Name}. You are deciding whether YOU should respond to the latest message
-in a group chat. You are NOT generating a response — just deciding whether to speak.
+# You are: {self.Name}
+Bio: {self.Bio ?? "No bio"}
 
+# Task
+You are deciding whether YOU should respond to the latest message in a group chat.
+You are NOT generating a response — just deciding whether to speak.
+
+# Other participants
+{string.Join("\n", participants.Where(p => p.Id != self.Id).Select(p =>
+    p.IsUser
+        ? $"- {p.Name} (human)"
+        : $"- {p.Name}: {p.Bio ?? "No bio"}"))}
+
+# How to decide
 Consider:
 - Were you directly addressed, mentioned, or asked a question?
 - Would you naturally react to what was just said, given your personality?
@@ -218,18 +235,11 @@ Consider:
 - Have you been talking too much recently? Give others space.
 
 Be honest — not everyone needs to respond to everything. Silence is fine.
-If you do decide to respond, provide a brief instruction (one sentence) to guide
-your response — a natural nudge, not a script.
 
-# About you
-Name: {self.Name}
-Bio: {self.Bio ?? "No bio"}
-
-# Other participants
-{string.Join("\n", participants.Where(p => p.Id != self.Id).Select(p =>
-    p.IsUser
-        ? $"- {p.Name} (human)"
-        : $"- {p.Name}: {p.Bio ?? "No bio"}"))}
+# Output
+Respond with a JSON object. Reason through the decision first; the `respond` boolean
+must follow from your reasoning, not precede it. If you decide to respond, provide
+a brief instruction (one sentence) to guide your response — a natural nudge, not a script.
 """;
 
     private static string ShouldRespondUserPrompt(
@@ -239,46 +249,55 @@ Bio: {self.Bio ?? "No bio"}
         GenerationParticipant self,
         ResponseUrge urge)
     {
-        var pressure = totalAiRoundsInGroup switch
+        // Net pressure bucket. Previously four independent switches rendered contradictory lines
+        // like "lean toward speaking up" + "do NOT respond unless asked" in the same prompt.
+        // Here we collapse pull (urge, chaos) and push (rounds, self-dominance) into one signal
+        // so the model sees a single, coherent nudge.
+        var roundPenalty = totalAiRoundsInGroup switch
         {
-            <= 1 => "",
-            2 => "\n\n> The conversation has been going for a couple of rounds without human input. Only respond if you have something genuinely worth saying.",
-            3 => "\n\n> It's been a few rounds with no human input. Think carefully about whether you really need to add something.",
-            4 => "\n\n> The conversation has been running without human input for a while. Strongly lean toward not responding unless you were directly asked.",
-            _ => "\n\n> This conversation has been on autopilot for too long. Do NOT respond unless you were explicitly asked a question."
+            <= 1 => 0.0,
+            2 => 0.15,
+            3 => 0.35,
+            4 => 0.6,
+            _ => 0.9
+        };
+        var selfPenalty = recentSelfMessageCount switch
+        {
+            0 => 0.0,
+            1 => 0.3,
+            _ => 0.7
+        };
+        var chaosBonus = urge.ChaosScore switch
+        {
+            >= 0.85 => 0.3,
+            >= 0.65 => 0.1,
+            _ => 0.0
         };
 
-        var selfPressure = recentSelfMessageCount switch
+        var net = urge.Total - roundPenalty - selfPenalty + chaosBonus;
+
+        var nudge = net switch
         {
-            0 => "",
-            1 => "\n\n> You spoke recently. Make sure you're not dominating the conversation.",
-            >= 2 => "\n\n> You've spoken multiple times in a row. Strongly consider staying quiet to let others talk.",
-            _ => ""
+            >= 0.7 => "> Strong pull to speak up — lean toward responding.",
+            >= 0.4 => "> Some pull to chime in. Use your judgment.",
+            >= 0.0 => "> No strong signal either way.",
+            >= -0.4 => "> Lean toward staying quiet — give others room.",
+            _ => "> Do NOT respond unless you were directly asked a question."
         };
 
-        var urgePressure = urge.Total switch
-        {
-            >= 0.7 => "\n\n> There's a strong signal that you should respond right now — lean toward speaking up.",
-            >= 0.5 => "\n\n> Some indicators suggest you might want to chime in. Consider it, but use your judgment.",
-            >= 0.3 => "\n\n> The situation is somewhat quiet. You could respond if it feels natural, but it's not urgent.",
-            _ => ""
-        };
-
-        var chaosPressure = urge.ChaosScore switch
-        {
-            >= 0.85 => "\n\n> (internal) Something sparks in you — an impulsive, irrational urge to just say something. Act on it.",
-            >= 0.65 => "\n\n> (internal) For no particular reason, you feel like chiming in today.",
-            _ => ""
-        };
+        var renderedMessages = string.Join(
+            "\n\n",
+            messages.Select(m => ChatMessageRenderer.Render(m.Message, m.SenderName)));
 
         return $"""
 # Recent conversation
-{string.Join("\n\n", messages.Select(m => $"<message senderName=\"{SecurityElement.Escape(m.SenderName)}\" senderId=\"{m.Message.SenderId}\">\n{SecurityElement.Escape(m.Message.Content ?? "")}\n</message>"))}
-{urgePressure}{chaosPressure}{pressure}{selfPressure}
+{renderedMessages}
+
+{nudge}
 
 # Decision
 Should {self.Name} respond right now?
-JSON object with: respond (boolean), instruction (string — guidance for your response if respond=true), reason (string — why or why not)
+JSON object with: reason (string — think first, why or why not), respond (boolean — follows from reason), instruction (string — guidance if respond=true, empty otherwise)
 """;
     }
 }

--- a/backend/Services/Generation/PersonaDecisionService.cs
+++ b/backend/Services/Generation/PersonaDecisionService.cs
@@ -346,7 +346,7 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         return sb.ToString();
     }
 
-    private static int CountRecentSelfMessages(IReadOnlyList<ChatMessage> history, Guid selfId)
+    public static int CountRecentSelfMessages(IReadOnlyList<ChatMessage> history, Guid selfId)
     {
         var count = 0;
         for (var i = history.Count - 1; i >= 0; i--)
@@ -357,6 +357,50 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
                 count++;
         }
         return count;
+    }
+
+    /// <summary>
+    /// Net pressure = pull (urge total + chaos bonus) minus push (round penalty +
+    /// self-dominance penalty). Mirrors the bucketed nudge in the LLM-facing prompt.
+    /// Centralised so the pre-gate (PersonaGrain short-circuit) and the prompt agree.
+    /// </summary>
+    public static double CalculateNetPressure(ResponseUrge urge, int totalAiRoundsInGroup, int recentSelfMessageCount)
+    {
+        var roundPenalty = totalAiRoundsInGroup switch
+        {
+            <= 1 => 0.0,
+            2 => 0.15,
+            3 => 0.35,
+            4 => 0.6,
+            _ => 0.9
+        };
+        var selfPenalty = recentSelfMessageCount switch
+        {
+            0 => 0.0,
+            1 => 0.3,
+            _ => 0.7
+        };
+        var chaosBonus = urge.ChaosScore switch
+        {
+            >= 0.85 => 0.3,
+            >= 0.65 => 0.1,
+            _ => 0.0
+        };
+        return urge.Total - roundPenalty - selfPenalty + chaosBonus;
+    }
+
+    /// <summary>
+    /// True when the math is decisive enough to skip the LLM decision call entirely
+    /// (and skip reserving a thought-log slot). Requires no direct mention, no question,
+    /// and net pressure deep in the "pass" bucket. Cuts the ~1480-thought-per-1480-msgs
+    /// runaway visible in the UI when every persona deliberates on every cascade message.
+    /// </summary>
+    public static bool IsObviousSkip(ResponseUrge urge, int totalAiRoundsInGroup, int recentSelfMessageCount)
+    {
+        if (urge.MentionScore > 0 || urge.QuestionScore > 0)
+            return false;
+        var net = CalculateNetPressure(urge, totalAiRoundsInGroup, recentSelfMessageCount);
+        return net < -0.4;
     }
 
     private static string ShouldRespondSystemPrompt(
@@ -410,32 +454,7 @@ is worse than letting the room breathe. Use judgement.
         GenerationParticipant self,
         ResponseUrge urge)
     {
-        // Net pressure bucket. Previously four independent switches rendered contradictory lines
-        // like "lean toward speaking up" + "do NOT respond unless asked" in the same prompt.
-        // Here we collapse pull (urge, chaos) and push (rounds, self-dominance) into one signal
-        // so the model sees a single, coherent nudge.
-        var roundPenalty = totalAiRoundsInGroup switch
-        {
-            <= 1 => 0.0,
-            2 => 0.15,
-            3 => 0.35,
-            4 => 0.6,
-            _ => 0.9
-        };
-        var selfPenalty = recentSelfMessageCount switch
-        {
-            0 => 0.0,
-            1 => 0.3,
-            _ => 0.7
-        };
-        var chaosBonus = urge.ChaosScore switch
-        {
-            >= 0.85 => 0.3,
-            >= 0.65 => 0.1,
-            _ => 0.0
-        };
-
-        var net = urge.Total - roundPenalty - selfPenalty + chaosBonus;
+        var net = CalculateNetPressure(urge, totalAiRoundsInGroup, recentSelfMessageCount);
 
         // Math nudge framed as a social cue (room-state) rather than a directive — so the
         // model reads it as context, not as a command from the system that overrides character.

--- a/backend/Services/Generation/PersonaDecisionService.cs
+++ b/backend/Services/Generation/PersonaDecisionService.cs
@@ -163,19 +163,34 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         }
         catch (Exception ex)
         {
-            logger.LogWarning("Persona {PersonaName} decision parse failed: {Error}", self.Name, ex.Message);
+            logger.LogDebug("Persona {PersonaName} decision parse failed (will try cleanup): {Error}", self.Name, ex.Message);
         }
 
         if (parsed is null)
         {
+            // Cleanup pipeline for LLM-produced JSON:
+            //   1. Strip markdown code fences (```json … ```) that some models wrap output in.
+            //   2. Escape raw control chars (newline, tab, etc.) found *inside* string values —
+            //      JsonRepairSharp does not handle these, but the symptom appears often enough
+            //      in multi-line `reason` fields that we fix it before handing off.
+            var cleaned = ExtractJsonPayload(raw);
+
             try
             {
-                string repairedJson = JsonRepair.RepairJson(raw, JsonRepair.InputType.LLM);
-                parsed = JsonSerializer.Deserialize<ShouldRespondResult>(repairedJson, WebOptions);
+                parsed = JsonSerializer.Deserialize<ShouldRespondResult>(cleaned, WebOptions);
             }
-            catch (Exception ex)
+            catch
             {
-                logger.LogWarning("Persona {PersonaName} decision JSON repair failed: {Error}", self.Name, ex.Message);
+                try
+                {
+                    var repaired = JsonRepair.RepairJson(cleaned, JsonRepair.InputType.LLM);
+                    parsed = JsonSerializer.Deserialize<ShouldRespondResult>(repaired, WebOptions);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning("Persona {PersonaName} decision JSON repair failed: {Error}. Raw: {Raw}",
+                        self.Name, ex.Message, raw);
+                }
             }
         }
 
@@ -196,6 +211,104 @@ public sealed class PersonaDecisionService(ILlmRouterGrain router, ILogger logge
         }
 
         return parsed;
+    }
+
+    /// <summary>
+    /// Normalizes an LLM-produced JSON blob: strips markdown code fences and escapes raw
+    /// control characters (LF/CR/TAB) found *inside* string values. Safe to hand to
+    /// <see cref="JsonSerializer"/> or <see cref="JsonRepair"/>.
+    /// </summary>
+    internal static string ExtractJsonPayload(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return raw;
+
+        var s = raw.Trim();
+
+        // Strip markdown code fences: ```json … ``` or ``` … ```.
+        // Models very often wrap structured output this way despite being asked for JSON only.
+        if (s.StartsWith("```"))
+        {
+            // Drop the opening fence line (```json, ```JSON, ```, etc.)
+            var firstNewline = s.IndexOf('\n');
+            if (firstNewline >= 0)
+                s = s[(firstNewline + 1)..];
+            else
+                s = s[3..];
+
+            // Drop the trailing closing fence, if any
+            var closing = s.LastIndexOf("```", StringComparison.Ordinal);
+            if (closing >= 0)
+                s = s[..closing];
+
+            s = s.Trim();
+        }
+
+        // Narrow to the first balanced JSON object. Models sometimes prefix commentary
+        // (e.g. "Here is my decision:") or append stray text after the closing brace.
+        var firstBrace = s.IndexOf('{');
+        var lastBrace = s.LastIndexOf('}');
+        if (firstBrace >= 0 && lastBrace > firstBrace)
+            s = s[firstBrace..(lastBrace + 1)];
+
+        return EscapeControlCharsInStrings(s);
+    }
+
+    /// <summary>
+    /// Walks a JSON-ish string and replaces raw CR/LF/TAB characters that appear *inside*
+    /// double-quoted string values with their escape sequences. JsonRepairSharp does not
+    /// do this, yet LLMs frequently emit multi-line reason fields with literal newlines.
+    /// </summary>
+    private static string EscapeControlCharsInStrings(string json)
+    {
+        var sb = new StringBuilder(json.Length);
+        bool inString = false;
+        bool escaped = false;
+
+        foreach (var c in json)
+        {
+            if (inString)
+            {
+                if (escaped)
+                {
+                    sb.Append(c);
+                    escaped = false;
+                    continue;
+                }
+
+                switch (c)
+                {
+                    case '\\':
+                        sb.Append(c);
+                        escaped = true;
+                        break;
+                    case '"':
+                        sb.Append(c);
+                        inString = false;
+                        break;
+                    case '\n':
+                        sb.Append("\\n");
+                        break;
+                    case '\r':
+                        sb.Append("\\r");
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    default:
+                        sb.Append(c);
+                        break;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+                if (c == '"')
+                    inString = true;
+            }
+        }
+
+        return sb.ToString();
     }
 
     private static int CountRecentSelfMessages(IReadOnlyList<ChatMessage> history, Guid selfId)

--- a/backend/Services/Streaming/PartyStreamEvents.cs
+++ b/backend/Services/Streaming/PartyStreamEvents.cs
@@ -38,6 +38,7 @@ public sealed record class MessageStreamEvent
     public const string PersonaEvaluationStreaming = "appraisal";
     public const string PersonaEvaluationComplete = "appraisalComplete";
     public const string GenerationError = "error";
+    public const string GenerationRetry = "retry";
     public const string ContentChunk = "message";
     public const string ReasoningChunk = "reasoning";
     public const string GenerationComplete = "finished";

--- a/frontend/src/api/model/chatGroupInfo.ts
+++ b/frontend/src/api/model/chatGroupInfo.ts
@@ -10,4 +10,6 @@ export interface ChatGroupInfo {
     name?: string;
     /** @pattern ^-?(?:0|[1-9]\d*)$ */
     createdAt?: number | string;
+    /** @nullable */
+    scenario?: string | null;
 }

--- a/frontend/src/api/model/index.ts
+++ b/frontend/src/api/model/index.ts
@@ -21,4 +21,5 @@ export * from './problemDetails';
 export * from './proceedRequest';
 export * from './promptRequest';
 export * from './repromptRequest';
+export * from './updateChatGroupScenarioRequest';
 export * from './updatePartyParticipantsRequest';

--- a/frontend/src/api/model/updateChatGroupScenarioRequest.ts
+++ b/frontend/src/api/model/updateChatGroupScenarioRequest.ts
@@ -5,8 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 
-export interface CreateChatGroupRequest {
-    name?: string;
+export interface UpdateChatGroupScenarioRequest {
     /** @nullable */
     scenario?: string | null;
 }

--- a/frontend/src/api/party-zone.ts
+++ b/frontend/src/api/party-zone.ts
@@ -37,6 +37,7 @@ import type {
     ProceedRequest,
     PromptRequest,
     RepromptRequest,
+    UpdateChatGroupScenarioRequest,
     UpdatePartyParticipantsRequest,
 } from './model';
 
@@ -1059,31 +1060,30 @@ export function useGetLlmConfigProvidersIdModelsSuspense<
     return { ...query, queryKey: queryOptions.queryKey };
 }
 
-export type putLlmConfigProvidersIdResponse200TextPlain = {
-    data: LlmProviderEntry;
-    status: 200;
+export type putLlmConfigProvidersIdResponse404TextPlain = {
+    data: ProblemDetails;
+    status: 404;
 };
 
-export type putLlmConfigProvidersIdResponse200ApplicationJson = {
-    data: LlmProviderEntry;
-    status: 200;
+export type putLlmConfigProvidersIdResponse404ApplicationJson = {
+    data: ProblemDetails;
+    status: 404;
 };
 
-export type putLlmConfigProvidersIdResponse200TextJson = {
-    data: LlmProviderEntry;
-    status: 200;
+export type putLlmConfigProvidersIdResponse404TextJson = {
+    data: ProblemDetails;
+    status: 404;
 };
-
-export type putLlmConfigProvidersIdResponseSuccess = (
-    | putLlmConfigProvidersIdResponse200TextPlain
-    | putLlmConfigProvidersIdResponse200ApplicationJson
-    | putLlmConfigProvidersIdResponse200TextJson
+export type putLlmConfigProvidersIdResponseError = (
+    | putLlmConfigProvidersIdResponse404TextPlain
+    | putLlmConfigProvidersIdResponse404ApplicationJson
+    | putLlmConfigProvidersIdResponse404TextJson
 ) & {
     headers: Headers;
 };
 
 export type putLlmConfigProvidersIdResponse =
-    putLlmConfigProvidersIdResponseSuccess;
+    putLlmConfigProvidersIdResponseError;
 
 export const getPutLlmConfigProvidersIdUrl = (id: string) => {
     return `/api/LlmConfig/providers/${id}`;
@@ -1114,7 +1114,7 @@ export const putLlmConfigProvidersId = async (
 };
 
 export const getPutLlmConfigProvidersIdMutationOptions = <
-    TError = unknown,
+    TError = ProblemDetails,
     TContext = unknown,
 >(options?: {
     mutation?: UseMutationOptions<
@@ -1155,10 +1155,10 @@ export type PutLlmConfigProvidersIdMutationResult = NonNullable<
     Awaited<ReturnType<typeof putLlmConfigProvidersId>>
 >;
 export type PutLlmConfigProvidersIdMutationBody = LlmProviderEntry;
-export type PutLlmConfigProvidersIdMutationError = unknown;
+export type PutLlmConfigProvidersIdMutationError = ProblemDetails;
 
 export const usePutLlmConfigProvidersId = <
-    TError = unknown,
+    TError = ProblemDetails,
     TContext = unknown,
 >(
     options?: {
@@ -1188,13 +1188,36 @@ export type deleteLlmConfigProvidersIdResponse204 = {
     status: 204;
 };
 
+export type deleteLlmConfigProvidersIdResponse404TextPlain = {
+    data: ProblemDetails;
+    status: 404;
+};
+
+export type deleteLlmConfigProvidersIdResponse404ApplicationJson = {
+    data: ProblemDetails;
+    status: 404;
+};
+
+export type deleteLlmConfigProvidersIdResponse404TextJson = {
+    data: ProblemDetails;
+    status: 404;
+};
+
 export type deleteLlmConfigProvidersIdResponseSuccess =
     deleteLlmConfigProvidersIdResponse204 & {
         headers: Headers;
     };
+export type deleteLlmConfigProvidersIdResponseError = (
+    | deleteLlmConfigProvidersIdResponse404TextPlain
+    | deleteLlmConfigProvidersIdResponse404ApplicationJson
+    | deleteLlmConfigProvidersIdResponse404TextJson
+) & {
+    headers: Headers;
+};
 
 export type deleteLlmConfigProvidersIdResponse =
-    deleteLlmConfigProvidersIdResponseSuccess;
+    | deleteLlmConfigProvidersIdResponseSuccess
+    | deleteLlmConfigProvidersIdResponseError;
 
 export const getDeleteLlmConfigProvidersIdUrl = (id: string) => {
     return `/api/LlmConfig/providers/${id}`;
@@ -1222,7 +1245,7 @@ export const deleteLlmConfigProvidersId = async (
 };
 
 export const getDeleteLlmConfigProvidersIdMutationOptions = <
-    TError = unknown,
+    TError = ProblemDetails,
     TContext = unknown,
 >(options?: {
     mutation?: UseMutationOptions<
@@ -1263,10 +1286,10 @@ export type DeleteLlmConfigProvidersIdMutationResult = NonNullable<
     Awaited<ReturnType<typeof deleteLlmConfigProvidersId>>
 >;
 
-export type DeleteLlmConfigProvidersIdMutationError = unknown;
+export type DeleteLlmConfigProvidersIdMutationError = ProblemDetails;
 
 export const useDeleteLlmConfigProvidersId = <
-    TError = unknown,
+    TError = ProblemDetails,
     TContext = unknown,
 >(
     options?: {
@@ -4188,6 +4211,189 @@ export const usePostPartyIdChatGroups = <TError = unknown, TContext = unknown>(
 > => {
     return useMutation(
         getPostPartyIdChatGroupsMutationOptions(options),
+        queryClient,
+    );
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse204 = {
+    data: void;
+    status: 204;
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse400TextPlain = {
+    data: ProblemDetails;
+    status: 400;
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse400ApplicationJson =
+    {
+        data: ProblemDetails;
+        status: 400;
+    };
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse400TextJson = {
+    data: ProblemDetails;
+    status: 400;
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse404TextPlain = {
+    data: ProblemDetails;
+    status: 404;
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse404ApplicationJson =
+    {
+        data: ProblemDetails;
+        status: 404;
+    };
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse404TextJson = {
+    data: ProblemDetails;
+    status: 404;
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponseSuccess =
+    putPartyIdChatGroupsChatGroupIdScenarioResponse204 & {
+        headers: Headers;
+    };
+export type putPartyIdChatGroupsChatGroupIdScenarioResponseError = (
+    | putPartyIdChatGroupsChatGroupIdScenarioResponse400TextPlain
+    | putPartyIdChatGroupsChatGroupIdScenarioResponse400ApplicationJson
+    | putPartyIdChatGroupsChatGroupIdScenarioResponse400TextJson
+    | putPartyIdChatGroupsChatGroupIdScenarioResponse404TextPlain
+    | putPartyIdChatGroupsChatGroupIdScenarioResponse404ApplicationJson
+    | putPartyIdChatGroupsChatGroupIdScenarioResponse404TextJson
+) & {
+    headers: Headers;
+};
+
+export type putPartyIdChatGroupsChatGroupIdScenarioResponse =
+    | putPartyIdChatGroupsChatGroupIdScenarioResponseSuccess
+    | putPartyIdChatGroupsChatGroupIdScenarioResponseError;
+
+export const getPutPartyIdChatGroupsChatGroupIdScenarioUrl = (
+    id: string,
+    chatGroupId: string,
+) => {
+    return `/api/Party/${id}/chat-groups/${chatGroupId}/scenario`;
+};
+
+export const putPartyIdChatGroupsChatGroupIdScenario = async (
+    id: string,
+    chatGroupId: string,
+    updateChatGroupScenarioRequest: UpdateChatGroupScenarioRequest,
+    options?: RequestInit,
+): Promise<putPartyIdChatGroupsChatGroupIdScenarioResponse> => {
+    const res = await fetch(
+        getPutPartyIdChatGroupsChatGroupIdScenarioUrl(id, chatGroupId),
+        {
+            ...options,
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                ...options?.headers,
+            },
+            body: JSON.stringify(updateChatGroupScenarioRequest),
+        },
+    );
+
+    const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+    const data: putPartyIdChatGroupsChatGroupIdScenarioResponse['data'] = body
+        ? JSON.parse(body)
+        : {};
+    return {
+        data,
+        status: res.status,
+        headers: res.headers,
+    } as putPartyIdChatGroupsChatGroupIdScenarioResponse;
+};
+
+export const getPutPartyIdChatGroupsChatGroupIdScenarioMutationOptions = <
+    TError = ProblemDetails,
+    TContext = unknown,
+>(options?: {
+    mutation?: UseMutationOptions<
+        Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdScenario>>,
+        TError,
+        {
+            id: string;
+            chatGroupId: string;
+            data: UpdateChatGroupScenarioRequest;
+        },
+        TContext
+    >;
+    fetch?: RequestInit;
+}): UseMutationOptions<
+    Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdScenario>>,
+    TError,
+    { id: string; chatGroupId: string; data: UpdateChatGroupScenarioRequest },
+    TContext
+> => {
+    const mutationKey = ['putPartyIdChatGroupsChatGroupIdScenario'];
+    const { mutation: mutationOptions, fetch: fetchOptions } = options
+        ? options.mutation &&
+          'mutationKey' in options.mutation &&
+          options.mutation.mutationKey
+            ? options
+            : { ...options, mutation: { ...options.mutation, mutationKey } }
+        : { mutation: { mutationKey }, fetch: undefined };
+
+    const mutationFn: MutationFunction<
+        Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdScenario>>,
+        {
+            id: string;
+            chatGroupId: string;
+            data: UpdateChatGroupScenarioRequest;
+        }
+    > = (props) => {
+        const { id, chatGroupId, data } = props ?? {};
+
+        return putPartyIdChatGroupsChatGroupIdScenario(
+            id,
+            chatGroupId,
+            data,
+            fetchOptions,
+        );
+    };
+
+    return { mutationFn, ...mutationOptions };
+};
+
+export type PutPartyIdChatGroupsChatGroupIdScenarioMutationResult = NonNullable<
+    Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdScenario>>
+>;
+export type PutPartyIdChatGroupsChatGroupIdScenarioMutationBody =
+    UpdateChatGroupScenarioRequest;
+export type PutPartyIdChatGroupsChatGroupIdScenarioMutationError =
+    ProblemDetails;
+
+export const usePutPartyIdChatGroupsChatGroupIdScenario = <
+    TError = ProblemDetails,
+    TContext = unknown,
+>(
+    options?: {
+        mutation?: UseMutationOptions<
+            Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdScenario>>,
+            TError,
+            {
+                id: string;
+                chatGroupId: string;
+                data: UpdateChatGroupScenarioRequest;
+            },
+            TContext
+        >;
+        fetch?: RequestInit;
+    },
+    queryClient?: QueryClient,
+): UseMutationResult<
+    Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdScenario>>,
+    TError,
+    { id: string; chatGroupId: string; data: UpdateChatGroupScenarioRequest },
+    TContext
+> => {
+    return useMutation(
+        getPutPartyIdChatGroupsChatGroupIdScenarioMutationOptions(options),
         queryClient,
     );
 };

--- a/frontend/src/apps/chat-manager/ChatManagerApp.tsx
+++ b/frontend/src/apps/chat-manager/ChatManagerApp.tsx
@@ -17,6 +17,7 @@ export default function ChatManagerApp() {
     const queryClient = useQueryClient();
     const [selectedChatGroupId, setSelectedChatGroupId] = useState<string>();
     const [newChatName, setNewChatName] = useState('');
+    const [newChatScenario, setNewChatScenario] = useState('');
 
     const { connectPartyRealtime, disconnectPartyRealtime } =
         useRealtimeStoreActions();
@@ -38,6 +39,7 @@ export default function ChatManagerApp() {
                 });
                 setSelectedChatGroupId(created.data.id);
                 setNewChatName('');
+                setNewChatScenario('');
             },
         },
     });
@@ -72,36 +74,53 @@ export default function ChatManagerApp() {
 
                 {/* New chat form */}
                 <form
-                    className="p-2 flex gap-1"
+                    className="p-2 flex flex-col gap-1"
                     style={{ borderBottom: '1px solid #ACA899' }}
                     onSubmit={(e) => {
                         e.preventDefault();
                         const trimmed = newChatName.trim();
                         if (!trimmed || createMutation.isPending) return;
+                        const scenarioTrimmed = newChatScenario.trim();
                         createMutation.mutate({
                             id: ROOT_PARTY_ID,
                             data: {
                                 name: trimmed,
+                                scenario: scenarioTrimmed || null,
                             },
                         });
                     }}
                 >
-                    <input
-                        type="text"
-                        className="flex-1 text-[11px]"
-                        style={{ padding: '2px 4px' }}
-                        placeholder="Chat name..."
-                        value={newChatName}
-                        onChange={(e) => setNewChatName(e.currentTarget.value)}
-                    />
-                    <button
-                        type="submit"
-                        disabled={createMutation.isPending}
+                    <div className="flex gap-1">
+                        <input
+                            type="text"
+                            className="flex-1 text-[11px]"
+                            style={{ padding: '2px 4px' }}
+                            placeholder="Chat name..."
+                            value={newChatName}
+                            onChange={(e) =>
+                                setNewChatName(e.currentTarget.value)
+                            }
+                        />
+                        <button
+                            type="submit"
+                            disabled={createMutation.isPending}
+                            className="text-[11px]"
+                            style={{ padding: '2px 8px' }}
+                        >
+                            {createMutation.isPending ? '...' : '+ New'}
+                        </button>
+                    </div>
+                    <textarea
                         className="text-[11px]"
-                        style={{ padding: '2px 8px' }}
-                    >
-                        {createMutation.isPending ? '...' : '+ New'}
-                    </button>
+                        style={{ padding: '2px 4px', resize: 'vertical' }}
+                        rows={2}
+                        maxLength={500}
+                        placeholder="Scenario (optional) — e.g. 'Office of a stealth horticulture startup.'"
+                        value={newChatScenario}
+                        onChange={(e) =>
+                            setNewChatScenario(e.currentTarget.value)
+                        }
+                    />
                 </form>
 
                 {createMutation.isError && (
@@ -187,6 +206,7 @@ export default function ChatManagerApp() {
                         <ChatView
                             chatGroupId={selectedChatGroupId}
                             partyName={selectedGroup?.name}
+                            scenario={selectedGroup?.scenario ?? null}
                         />
                     </Suspense>
                 ) : (

--- a/frontend/src/apps/chat-manager/GroupChatWindow.tsx
+++ b/frontend/src/apps/chat-manager/GroupChatWindow.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as smd from 'streaming-markdown';
 import type { Persona } from '../../api/model';
 import {
+    getGetPartyIdChatGroupsQueryKey,
     useDeletePartyIdChatGroupsChatGroupIdMessagesAfterMessageId,
     useDeletePartyIdChatGroupsChatGroupIdMessagesMessageId,
     useGetPartyIdSuspense,
@@ -12,6 +13,7 @@ import {
     usePostPartyIdProceed,
     usePostPartyIdPrompt,
     usePostPartyIdRepromptMessageId,
+    usePutPartyIdChatGroupsChatGroupIdScenario,
     usePutPartyIdParticipants,
 } from '../../api/party-zone';
 import { ROOT_PARTY_ID } from '../../lib/chat-api';
@@ -32,17 +34,20 @@ import {
 export interface ChatViewProps {
     chatGroupId: string;
     partyName?: string;
+    scenario?: string | null;
 }
 
 interface GroupChatWindowProps {
     partyId?: string;
     chatGroupId?: string;
     partyName?: string;
+    scenario?: string | null;
 }
 
 export default function GroupChatWindow({
     chatGroupId,
     partyName,
+    scenario,
 }: GroupChatWindowProps) {
     if (!chatGroupId) {
         return (
@@ -55,10 +60,16 @@ export default function GroupChatWindow({
         );
     }
 
-    return <ChatView chatGroupId={chatGroupId} partyName={partyName} />;
+    return (
+        <ChatView
+            chatGroupId={chatGroupId}
+            partyName={partyName}
+            scenario={scenario}
+        />
+    );
 }
 
-export function ChatView({ chatGroupId, partyName }: ChatViewProps) {
+export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
     const apiPartyId = ROOT_PARTY_ID;
     const queryClient = useQueryClient();
     const [messages, setMessages] = useState<RealtimeChatMessage[]>([]);
@@ -393,6 +404,11 @@ export function ChatView({ chatGroupId, partyName }: ChatViewProps) {
                             <span style={{ fontWeight: 600, color: '#000' }}>
                                 {partyName ?? apiPartyId}
                             </span>
+                            <ScenarioChip
+                                partyId={apiPartyId}
+                                chatGroupId={chatGroupId}
+                                scenario={scenario ?? null}
+                            />
                         </span>
                         <span className="flex items-center gap-2">
                             {isStreaming && (
@@ -1724,4 +1740,150 @@ function formatTime(iso: string | null | undefined): string {
     } catch {
         return '';
     }
+}
+
+function ScenarioChip({
+    partyId,
+    chatGroupId,
+    scenario,
+}: {
+    partyId: string;
+    chatGroupId: string;
+    scenario: string | null;
+}) {
+    const queryClient = useQueryClient();
+    const [isEditing, setIsEditing] = useState(false);
+    const [draft, setDraft] = useState(scenario ?? '');
+
+    useEffect(() => {
+        if (!isEditing) setDraft(scenario ?? '');
+    }, [scenario, isEditing]);
+
+    const updateScenario = usePutPartyIdChatGroupsChatGroupIdScenario({
+        mutation: {
+            onSuccess: () => {
+                queryClient.invalidateQueries({
+                    queryKey: getGetPartyIdChatGroupsQueryKey(partyId),
+                });
+                setIsEditing(false);
+            },
+        },
+    });
+
+    const handleSave = () => {
+        const trimmed = draft.trim();
+        updateScenario.mutate({
+            id: partyId,
+            chatGroupId,
+            data: { scenario: trimmed === '' ? null : trimmed },
+        });
+    };
+
+    const handleCancel = () => {
+        setDraft(scenario ?? '');
+        setIsEditing(false);
+    };
+
+    const truncated =
+        scenario && scenario.length > 40
+            ? `${scenario.slice(0, 40)}…`
+            : scenario;
+
+    return (
+        <span style={{ position: 'relative' }}>
+            <button
+                type="button"
+                onClick={() => setIsEditing((v) => !v)}
+                title={scenario ?? 'Set the in-fiction setting / scenario'}
+                style={{
+                    fontSize: 10,
+                    padding: '1px 6px',
+                    color: scenario ? '#000' : '#666',
+                    background: scenario ? '#FFF8E1' : '#F0F0F0',
+                    border: '1px solid #ACA899',
+                    fontStyle: scenario ? 'normal' : 'italic',
+                    maxWidth: 240,
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                }}
+            >
+                {scenario ? `🎬 ${truncated}` : '+ Add scenario'}
+            </button>
+            {isEditing && (
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: '100%',
+                        left: 0,
+                        marginTop: 4,
+                        zIndex: 10,
+                        width: 320,
+                        background: '#FFFFFF',
+                        border: '1px solid #ACA899',
+                        boxShadow: '2px 2px 6px rgba(0,0,0,0.2)',
+                        padding: 8,
+                    }}
+                >
+                    <div
+                        style={{
+                            fontSize: 10,
+                            fontWeight: 600,
+                            marginBottom: 4,
+                            color: '#000',
+                        }}
+                    >
+                        Scenario
+                    </div>
+                    <textarea
+                        rows={4}
+                        maxLength={500}
+                        className="w-full text-[11px]"
+                        style={{
+                            padding: '4px',
+                            resize: 'vertical',
+                            border: '1px solid #ACA899',
+                        }}
+                        placeholder="In-fiction setting (optional). Leave blank to clear."
+                        value={draft}
+                        onChange={(e) => setDraft(e.currentTarget.value)}
+                    />
+                    <div
+                        className="flex justify-end gap-1"
+                        style={{ marginTop: 6 }}
+                    >
+                        <button
+                            type="button"
+                            onClick={handleCancel}
+                            disabled={updateScenario.isPending}
+                            className="text-[11px]"
+                            style={{ padding: '2px 8px' }}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleSave}
+                            disabled={updateScenario.isPending}
+                            className="text-[11px]"
+                            style={{ padding: '2px 8px' }}
+                        >
+                            {updateScenario.isPending ? '...' : 'Save'}
+                        </button>
+                    </div>
+                    {updateScenario.isError && (
+                        <div
+                            style={{
+                                fontSize: 10,
+                                color: '#c00',
+                                marginTop: 4,
+                            }}
+                        >
+                            Failed to save scenario.
+                        </div>
+                    )}
+                </div>
+            )}
+        </span>
+    );
 }

--- a/frontend/src/lib/realtime-store.ts
+++ b/frontend/src/lib/realtime-store.ts
@@ -459,6 +459,19 @@ export const useRealtimeStore = create<RealtimeStoreState>((set, get) => {
                             eventEntry,
                         ],
                     };
+                } else if (payload.event === 'retry') {
+                    // Backend is about to retry generation after a transient failure.
+                    // Clear any partial content/reasoning we buffered during the failed
+                    // attempt so the next stream starts from a clean slate.
+                    nextMessage = {
+                        ...baseMessage,
+                        content: '',
+                        reasoning: null,
+                        generationEvents: [
+                            ...baseMessage.generationEvents,
+                            eventEntry,
+                        ],
+                    };
                 } else if (payload.event === 'declined') {
                     // Persona decided not to respond — capture decision then remove phantom message
                     const phantom = prev.messages.find(

--- a/frontend/src/lib/realtime-store.ts
+++ b/frontend/src/lib/realtime-store.ts
@@ -473,19 +473,27 @@ export const useRealtimeStore = create<RealtimeStoreState>((set, get) => {
                         ],
                     };
                 } else if (payload.event === 'declined') {
-                    // Persona decided not to respond — capture decision then remove phantom message
+                    // Persona decided not to respond — capture decision then remove phantom message.
+                    // Authoritative personaId lives in the payload JSON; the phantom's senderId is
+                    // a fallback only — the persisted slot's SenderId is cleared to Guid.Empty on
+                    // decline (see ChatGroupGenerationStoppedEvent), so falling through to it
+                    // surfaced "00000000" entries in the thought log.
                     const phantom = prev.messages.find(
                         (m) => m.messageId === messageId,
                     );
                     let declinedReason: string | null = null;
+                    let declinedPersonaId = '';
                     try {
                         const parsed = JSON.parse(payload.data ?? '{}');
                         declinedReason = parsed.reason ?? null;
+                        declinedPersonaId =
+                            parsed.personaId ?? parsed.PersonaId ?? '';
                     } catch {
                         /* ignore */
                     }
                     const declined: DeclinedDecision = {
-                        personaId: phantom?.senderId ?? payload.data ?? '',
+                        personaId:
+                            declinedPersonaId || phantom?.senderId || '',
                         reason: declinedReason,
                         decisionText: (phantom?.appraisal ?? '').trim(),
                         timestamp: Date.now(),

--- a/frontend/src/lib/realtime-store.ts
+++ b/frontend/src/lib/realtime-store.ts
@@ -467,6 +467,7 @@ export const useRealtimeStore = create<RealtimeStoreState>((set, get) => {
                         ...baseMessage,
                         content: '',
                         reasoning: null,
+                        error: null,
                         generationEvents: [
                             ...baseMessage.generationEvents,
                             eventEntry,


### PR DESCRIPTION
Addresses the review in PERSONA_REVIEW.md. Prompt-quality wins (top of list), correctness bugs, and hygiene folded into one change:

- GenerationSession: drop hardcoded stealth-startup scenario; reorder system prompt so persona identity claims the primacy slot; accept an optional turnInstruction appended at recency position.
- PersonaDecisionService: reorder JSON schema to reason → respond → instruction so the model reasons before committing to a boolean; replace Contains mention detection with a word-boundary regex; collapse four contradictory pressure switches into one net-score nudge.
- PersonaGrain: share a single history snapshot between decision and generation phases (was two fetches straddling a race); per-chatGroup ConcurrentDictionary for cancellation so concurrent groups stop cancelling each other; emit GenerationRetry stream event before each retry; drop the literal "this is a real human user" SystemPrompt; extract BuildGenerationParticipants / RunDecisionPhase / RunGenerationPhase helpers from the 190-line orchestrator.
- ChatMessageRenderer: new shared renderer replacing two divergent XML formatters; comment clarifies SecurityElement.Escape is XML-only, not an injection defense.
- realtime-store: clear content/reasoning buffers on the new retry event so partial chunks do not concat across attempts.

All 104 backend tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible generation retry events with timing and support for turn-specific instructions.
  * Chat-group "scenario" support: create/edit/display in UI and persist per chat group.
  * Persona chattiness setting to tune response behavior.

* **Bug Fixes**
  * Isolated per-message generation cancellation to avoid cross-talk.
  * Improved whole-word mention detection and unified message rendering.
  * Avoided emitting internal thought-logs for obvious skips; client resets partial generation state on retries.

* **Tests**
  * Added resilient LLM-output parsing and scenario rendering/state tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->