### PR TITLE
feat(chat): per-chat-group participants + Discord-style member list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ docker compose down -v     # Stop and wipe DB
 - **Database**: localhost:${HOST_DB_PORT:-5455} (PostgreSQL + Apache AGE)
 - **Aspire Dashboard**: http://localhost:18888 (OpenTelemetry traces/metrics/logs)
 
-Frontend + backend hot-reload on changes.
+If development-docker runs, frontend + backend hot-reload on changes. This dev-docker is often running so check first before trying to start one of the services yourself/
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,8 @@ DB init scripts in `docker-entrypoint-initdb.d/`. Re-run: wipe volume (`docker c
 
 **Code style:** Biome for linting/formatting — 4-space indent, single quotes, trailing commas. No Prettier/ESLint.
 
+**After frontend changes:** run `npx biome check --write` (auto-fix lint/format) and `npx tsc --noEmit` (type-check) from `frontend/`. Vite hot-reload doesn't catch type errors or lint warnings — CI does. Fix before declaring task done.
+
 ### Infrastructure
 
 - **Caddy** reverse proxy routes API traffic to backend

--- a/backend/Controllers/PartyController.cs
+++ b/backend/Controllers/PartyController.cs
@@ -136,6 +136,65 @@ public sealed class PartyController(
         return Ok(current);
     }
 
+    /// <summary>
+    /// Updates the participants of a specific chat group within a party.
+    /// </summary>
+    /// <param name="id">The party identifier.</param>
+    /// <param name="chatGroupId">The chat group identifier.</param>
+    /// <param name="request">The participant list. Each id must exist in the party roster.</param>
+    /// <returns>
+    /// <c>200 OK</c> with the updated participant list;
+    /// <c>400 Bad Request</c> if any participant id is not in the party roster;
+    /// <c>404 Not Found</c> if the party does not exist.
+    /// </returns>
+    [HttpPut("{id:guid}/chat-groups/{chatGroupId:guid}/participants")]
+    public async Task<ActionResult<List<PartyParticipant>>> SetChatGroupParticipants(
+        Guid id,
+        Guid chatGroupId,
+        [FromBody] UpdatePartyParticipantsRequest request)
+    {
+        if (chatGroupId == Guid.Empty)
+        {
+            return BadRequest("Invalid chat group id");
+        }
+
+        var root = grains.GetGrain<IPartyRootGrain>(Guid.Empty);
+        await EnsureDefaultParty(root, id);
+        if (!await root.HasPartyId(id))
+        {
+            return NotFound();
+        }
+
+        var party = await grains.GetGrain<IPartyGrain>(id).GetParty();
+        var partyIds = party.Participants.Select(p => p.Id).ToHashSet();
+
+        var participants = (request.Participants ?? [])
+            .Where(p => p.Id != Guid.Empty)
+            .GroupBy(p => p.Id)
+            .Select(group =>
+            {
+                var p = group.First();
+                return new PartyParticipant
+                {
+                    Id = p.Id,
+                    Name = string.IsNullOrWhiteSpace(p.Name) ? p.Id.ToString() : p.Name.Trim(),
+                    IsUser = p.IsUser
+                };
+            })
+            .ToList();
+
+        var invalid = participants.Where(p => !partyIds.Contains(p.Id)).Select(p => p.Id).ToList();
+        if (invalid.Count > 0)
+        {
+            return BadRequest($"Participants not in party roster: {string.Join(", ", invalid)}");
+        }
+
+        var chatGroupGrain = grains.GetGrain<IChatGroupGrain>(chatGroupId);
+        await chatGroupGrain.SetParticipantsAsync(participants);
+        var updated = await chatGroupGrain.GetParticipantsAsync();
+        return Ok(updated);
+    }
+
     [HttpPut("{id:guid}/participants")]
     public async Task<ActionResult<PartyInfo>> SetParticipants(Guid id, [FromBody] UpdatePartyParticipantsRequest request)
     {

--- a/backend/Controllers/PersonaController.cs
+++ b/backend/Controllers/PersonaController.cs
@@ -142,6 +142,32 @@ public class PersonaController(
         var personaGrain = grains.GetGrain<IPersonaGrain>(personaId);
         var updated = await personaGrain.GetPersona();
 
+        // Single-party assumption: every persona is a member of the default party roster.
+        // Ensures new personas show up in the "+" invite dropdown across chat groups.
+        var defaultPartyGrain = grains.GetGrain<IPartyGrain>(Guid.Empty);
+        var defaultParty = await defaultPartyGrain.GetParty();
+        if (!defaultParty.Participants.Any(p => p.Id == personaId))
+        {
+            var roster = new List<PartyParticipant>(defaultParty.Participants)
+            {
+                new() { Id = personaId, Name = updated.Name ?? persona.Name, IsUser = false }
+            };
+            await defaultPartyGrain.SetParticipants(roster);
+        }
+        else
+        {
+            // Update the stored name if it changed
+            var roster = defaultParty.Participants
+                .Select(p => p.Id == personaId
+                    ? new PartyParticipant { Id = p.Id, Name = updated.Name ?? persona.Name, IsUser = p.IsUser }
+                    : p)
+                .ToList();
+            if (!roster.SequenceEqual(defaultParty.Participants))
+            {
+                await defaultPartyGrain.SetParticipants(roster);
+            }
+        }
+
         if (isNew)
         {
             logger.LogInformation("Persona created: {PersonaId}", personaId);
@@ -172,6 +198,17 @@ public class PersonaController(
 
         logger.LogInformation("Deleting persona: {PersonaId}", id);
         await root.RemovePersona(id);
+
+        // Cascade: remove from default party roster.
+        // PartyGrain.SetParticipants will cascade the removal to all chat groups.
+        var defaultPartyGrain = grains.GetGrain<IPartyGrain>(Guid.Empty);
+        var defaultParty = await defaultPartyGrain.GetParty();
+        if (defaultParty.Participants.Any(p => p.Id == id))
+        {
+            var roster = defaultParty.Participants.Where(p => p.Id != id).ToList();
+            await defaultPartyGrain.SetParticipants(roster);
+        }
+
         return NoContent();
     }
 

--- a/backend/Grains/ChatGroupGrain.cs
+++ b/backend/Grains/ChatGroupGrain.cs
@@ -91,6 +91,13 @@ public sealed class ChatGroupGrain(ILogger<ChatGroupGrain> logger)
 
         RaiseEvent(new ChatGroupParticipantsSetEvent { Participants = [.. participants] });
         await ConfirmEvents();
+
+        await PublishPartyEvent(new PartyStreamEvent
+        {
+            Type = "chatGroupParticipants",
+            ChatGroupId = this.GetPrimaryKey(),
+            Participants = participants.ToList()
+        });
     }
 
     public async Task<ChatMessage> SendNewMessageAsync(

--- a/backend/Grains/PartyGrain.cs
+++ b/backend/Grains/PartyGrain.cs
@@ -47,6 +47,10 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
 
     public async Task SetParticipants(List<PartyParticipant> participants)
     {
+        var previousIds = State.Participants.Select(p => p.Id).ToHashSet();
+        var newIds = participants.Select(p => p.Id).ToHashSet();
+        var removedIds = previousIds.Except(newIds).ToHashSet();
+
         RaiseEvent(new ParticipantsSetEvent
         {
             Participants = [.. participants]
@@ -54,15 +58,37 @@ public sealed class PartyGrain(ILogger<PartyGrain> logger)
 
         await ConfirmEvents();
 
-        // Propagate participants to all chat group grains
-        var tasks = State.ChatGroups.Select(cg =>
-            GrainFactory.GetGrain<IChatGroupGrain>(cg.Id)
-                .SetParticipantsAsync(participants));
-        await Task.WhenAll(tasks);
+        // Additions do NOT auto-propagate to chat groups — users invite per chat group.
+        // Removals cascade: a persona removed from the party is removed from every chat group.
+        if (removedIds.Count > 0)
+        {
+            var tasks = State.ChatGroups.Select(async cg =>
+            {
+                var grain = GrainFactory.GetGrain<IChatGroupGrain>(cg.Id);
+                var current = await grain.GetParticipantsAsync();
+                if (current.Any(p => removedIds.Contains(p.Id)))
+                {
+                    var filtered = current.Where(p => !removedIds.Contains(p.Id)).ToList();
+                    await grain.SetParticipantsAsync(filtered);
+                }
+            });
+            await Task.WhenAll(tasks);
+        }
     }
 
-    public Task<List<ChatGroupInfo>> GetChatGroups()
-        => Task.FromResult(State.ChatGroups.ToList());
+    public async Task<List<ChatGroupInfo>> GetChatGroups()
+    {
+        var groups = State.ChatGroups.ToList();
+        var hydrated = new List<ChatGroupInfo>(groups.Count);
+        foreach (var group in groups)
+        {
+            var participants = await GrainFactory
+                .GetGrain<IChatGroupGrain>(group.Id)
+                .GetParticipantsAsync();
+            hydrated.Add(group with { Participants = participants });
+        }
+        return hydrated;
+    }
 
     public async Task<ChatGroupInfo> CreateChatGroup(string name, string? scenario = null)
     {

--- a/backend/Model/Party.cs
+++ b/backend/Model/Party.cs
@@ -47,6 +47,10 @@ public sealed record class ChatGroupInfo
 
     [Id(3)]
     public string? Scenario { get; set; }
+
+    // Hydrated at API boundary from ChatGroupGrain; not persisted in PartyState.
+    [Id(4)]
+    public List<PartyParticipant> Participants { get; set; } = [];
 }
 
 public sealed record class CreateChatGroupRequest

--- a/backend/Services/Streaming/PartyStreamEvents.cs
+++ b/backend/Services/Streaming/PartyStreamEvents.cs
@@ -24,6 +24,9 @@ public sealed record class PartyStreamEvent
 
     [Id(4)]
     public MessageStreamEvent? MessageEvent { get; init; }
+
+    [Id(5)]
+    public List<PartyParticipant>? Participants { get; init; }
 }
 
 /// <summary>

--- a/frontend/src/api/model/chatGroupInfo.ts
+++ b/frontend/src/api/model/chatGroupInfo.ts
@@ -4,6 +4,7 @@
  * backend | v1
  * OpenAPI spec version: 1.0.0
  */
+import type { PartyParticipant } from './partyParticipant';
 
 export interface ChatGroupInfo {
     id?: string;
@@ -12,4 +13,5 @@ export interface ChatGroupInfo {
     createdAt?: number | string;
     /** @nullable */
     scenario?: string | null;
+    participants?: PartyParticipant[];
 }

--- a/frontend/src/api/model/createChatGroupRequest.ts
+++ b/frontend/src/api/model/createChatGroupRequest.ts
@@ -7,6 +7,9 @@
 
 export interface CreateChatGroupRequest {
     name?: string;
-    /** @nullable */
+    /**
+     * @maxLength 2000
+     * @nullable
+     */
     scenario?: string | null;
 }

--- a/frontend/src/api/model/persona.ts
+++ b/frontend/src/api/model/persona.ts
@@ -9,6 +9,8 @@ export interface Persona {
     systemPrompt?: string;
     /** @nullable */
     bio?: string | null;
+    /** @pattern ^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$ */
+    chattiness?: number | string;
     id?: string;
     name?: string;
     isUser?: boolean;

--- a/frontend/src/api/model/updateChatGroupScenarioRequest.ts
+++ b/frontend/src/api/model/updateChatGroupScenarioRequest.ts
@@ -6,6 +6,9 @@
  */
 
 export interface UpdateChatGroupScenarioRequest {
-    /** @nullable */
+    /**
+     * @maxLength 2000
+     * @nullable
+     */
     scenario?: string | null;
 }

--- a/frontend/src/api/party-zone.ts
+++ b/frontend/src/api/party-zone.ts
@@ -32,6 +32,7 @@ import type {
     LlmProviderEntry,
     PartyDetails,
     PartyInfo,
+    PartyParticipant,
     Persona,
     ProblemDetails,
     ProceedRequest,
@@ -2147,6 +2148,161 @@ export const usePostPartyIdResetParticipants = <
 > => {
     return useMutation(
         getPostPartyIdResetParticipantsMutationOptions(options),
+        queryClient,
+    );
+};
+
+export type putPartyIdChatGroupsChatGroupIdParticipantsResponse200TextPlain = {
+    data: PartyParticipant[];
+    status: 200;
+};
+
+export type putPartyIdChatGroupsChatGroupIdParticipantsResponse200ApplicationJson =
+    {
+        data: PartyParticipant[];
+        status: 200;
+    };
+
+export type putPartyIdChatGroupsChatGroupIdParticipantsResponse200TextJson = {
+    data: PartyParticipant[];
+    status: 200;
+};
+
+export type putPartyIdChatGroupsChatGroupIdParticipantsResponseSuccess = (
+    | putPartyIdChatGroupsChatGroupIdParticipantsResponse200TextPlain
+    | putPartyIdChatGroupsChatGroupIdParticipantsResponse200ApplicationJson
+    | putPartyIdChatGroupsChatGroupIdParticipantsResponse200TextJson
+) & {
+    headers: Headers;
+};
+
+export type putPartyIdChatGroupsChatGroupIdParticipantsResponse =
+    putPartyIdChatGroupsChatGroupIdParticipantsResponseSuccess;
+
+export const getPutPartyIdChatGroupsChatGroupIdParticipantsUrl = (
+    id: string,
+    chatGroupId: string,
+) => {
+    return `/api/Party/${id}/chat-groups/${chatGroupId}/participants`;
+};
+
+export const putPartyIdChatGroupsChatGroupIdParticipants = async (
+    id: string,
+    chatGroupId: string,
+    updatePartyParticipantsRequest: UpdatePartyParticipantsRequest,
+    options?: RequestInit,
+): Promise<putPartyIdChatGroupsChatGroupIdParticipantsResponse> => {
+    const res = await fetch(
+        getPutPartyIdChatGroupsChatGroupIdParticipantsUrl(id, chatGroupId),
+        {
+            ...options,
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                ...options?.headers,
+            },
+            body: JSON.stringify(updatePartyParticipantsRequest),
+        },
+    );
+
+    const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+    const data: putPartyIdChatGroupsChatGroupIdParticipantsResponse['data'] =
+        body ? JSON.parse(body) : {};
+    return {
+        data,
+        status: res.status,
+        headers: res.headers,
+    } as putPartyIdChatGroupsChatGroupIdParticipantsResponse;
+};
+
+export const getPutPartyIdChatGroupsChatGroupIdParticipantsMutationOptions = <
+    TError = unknown,
+    TContext = unknown,
+>(options?: {
+    mutation?: UseMutationOptions<
+        Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdParticipants>>,
+        TError,
+        {
+            id: string;
+            chatGroupId: string;
+            data: UpdatePartyParticipantsRequest;
+        },
+        TContext
+    >;
+    fetch?: RequestInit;
+}): UseMutationOptions<
+    Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdParticipants>>,
+    TError,
+    { id: string; chatGroupId: string; data: UpdatePartyParticipantsRequest },
+    TContext
+> => {
+    const mutationKey = ['putPartyIdChatGroupsChatGroupIdParticipants'];
+    const { mutation: mutationOptions, fetch: fetchOptions } = options
+        ? options.mutation &&
+          'mutationKey' in options.mutation &&
+          options.mutation.mutationKey
+            ? options
+            : { ...options, mutation: { ...options.mutation, mutationKey } }
+        : { mutation: { mutationKey }, fetch: undefined };
+
+    const mutationFn: MutationFunction<
+        Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdParticipants>>,
+        {
+            id: string;
+            chatGroupId: string;
+            data: UpdatePartyParticipantsRequest;
+        }
+    > = (props) => {
+        const { id, chatGroupId, data } = props ?? {};
+
+        return putPartyIdChatGroupsChatGroupIdParticipants(
+            id,
+            chatGroupId,
+            data,
+            fetchOptions,
+        );
+    };
+
+    return { mutationFn, ...mutationOptions };
+};
+
+export type PutPartyIdChatGroupsChatGroupIdParticipantsMutationResult =
+    NonNullable<
+        Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdParticipants>>
+    >;
+export type PutPartyIdChatGroupsChatGroupIdParticipantsMutationBody =
+    UpdatePartyParticipantsRequest;
+export type PutPartyIdChatGroupsChatGroupIdParticipantsMutationError = unknown;
+
+export const usePutPartyIdChatGroupsChatGroupIdParticipants = <
+    TError = unknown,
+    TContext = unknown,
+>(
+    options?: {
+        mutation?: UseMutationOptions<
+            Awaited<
+                ReturnType<typeof putPartyIdChatGroupsChatGroupIdParticipants>
+            >,
+            TError,
+            {
+                id: string;
+                chatGroupId: string;
+                data: UpdatePartyParticipantsRequest;
+            },
+            TContext
+        >;
+        fetch?: RequestInit;
+    },
+    queryClient?: QueryClient,
+): UseMutationResult<
+    Awaited<ReturnType<typeof putPartyIdChatGroupsChatGroupIdParticipants>>,
+    TError,
+    { id: string; chatGroupId: string; data: UpdatePartyParticipantsRequest },
+    TContext
+> => {
+    return useMutation(
+        getPutPartyIdChatGroupsChatGroupIdParticipantsMutationOptions(options),
         queryClient,
     );
 };

--- a/frontend/src/api/party-zone.ts
+++ b/frontend/src/api/party-zone.ts
@@ -43,7 +43,7 @@ import type {
 } from './model';
 
 export type getUpResponse204 = {
-    data: void;
+    data: undefined;
     status: 204;
 };
 
@@ -1185,7 +1185,7 @@ export const usePutLlmConfigProvidersId = <
 };
 
 export type deleteLlmConfigProvidersIdResponse204 = {
-    data: void;
+    data: undefined;
     status: 204;
 };
 
@@ -2429,7 +2429,7 @@ export const usePutPartyIdParticipants = <TError = unknown, TContext = unknown>(
 };
 
 export type postPartyIdPromptResponse202 = {
-    data: void;
+    data: undefined;
     status: 202;
 };
 
@@ -2562,7 +2562,7 @@ export const usePostPartyIdPrompt = <
 };
 
 export type postPartyIdProceedResponse202 = {
-    data: void;
+    data: undefined;
     status: 202;
 };
 
@@ -2696,7 +2696,7 @@ export const usePostPartyIdProceed = <
 };
 
 export type postPartyIdCancelResponse204 = {
-    data: void;
+    data: undefined;
     status: 204;
 };
 
@@ -2799,7 +2799,7 @@ export const usePostPartyIdCancel = <TError = unknown, TContext = unknown>(
 };
 
 export type deletePartyIdChatGroupsChatGroupIdMessagesMessageIdResponse204 = {
-    data: void;
+    data: undefined;
     status: 204;
 };
 
@@ -2977,7 +2977,7 @@ export const useDeletePartyIdChatGroupsChatGroupIdMessagesMessageId = <
 
 export type deletePartyIdChatGroupsChatGroupIdMessagesAfterMessageIdResponse204 =
     {
-        data: void;
+        data: undefined;
         status: 204;
     };
 
@@ -3157,7 +3157,7 @@ export const useDeletePartyIdChatGroupsChatGroupIdMessagesAfterMessageId = <
 };
 
 export type postPartyIdRepromptMessageIdResponse202 = {
-    data: void;
+    data: undefined;
     status: 202;
 };
 
@@ -3295,7 +3295,7 @@ export const usePostPartyIdRepromptMessageId = <
 };
 
 export type getPartyIdWsResponse200 = {
-    data: void;
+    data: undefined;
     status: 200;
 };
 
@@ -4372,7 +4372,7 @@ export const usePostPartyIdChatGroups = <TError = unknown, TContext = unknown>(
 };
 
 export type putPartyIdChatGroupsChatGroupIdScenarioResponse204 = {
-    data: void;
+    data: undefined;
     status: 204;
 };
 
@@ -5288,7 +5288,7 @@ export const usePutPersonaId = <TError = unknown, TContext = unknown>(
 };
 
 export type deletePersonaIdResponse200 = {
-    data: void;
+    data: undefined;
     status: 200;
 };
 
@@ -5689,7 +5689,7 @@ export function useGetPersonaDefaultsSuspense<
 }
 
 export type getPersonaWsResponse200 = {
-    data: void;
+    data: undefined;
     status: 200;
 };
 

--- a/frontend/src/apps/chat-manager/ChatManagerApp.tsx
+++ b/frontend/src/apps/chat-manager/ChatManagerApp.tsx
@@ -1,17 +1,16 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { Suspense, useState } from 'react';
-import { ChatView } from './GroupChatWindow';
-import { ROOT_PARTY_ID } from '../../lib/chat-api';
-import {
-    useRealtimeConnectionStatus,
-    useRealtimeStoreActions,
-} from '../../lib/realtime-store';
-import { useEffect } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import {
     getGetPartyIdChatGroupsQueryKey,
     useGetPartyIdChatGroupsSuspense,
     usePostPartyIdChatGroups,
 } from '../../api/party-zone';
+import { ROOT_PARTY_ID } from '../../lib/chat-api';
+import {
+    useRealtimeConnectionStatus,
+    useRealtimeStoreActions,
+} from '../../lib/realtime-store';
+import { ChatView } from './GroupChatWindow';
 
 export default function ChatManagerApp() {
     const queryClient = useQueryClient();

--- a/frontend/src/apps/chat-manager/GroupChatWindow.tsx
+++ b/frontend/src/apps/chat-manager/GroupChatWindow.tsx
@@ -279,9 +279,7 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
         (nextAiIds: string[]) => {
             if (partyDetailsQuery.data.status !== 200) return;
             const personas = partyDetailsQuery.data.data.personaParticipants;
-            const personaNameMap = new Map(
-                personas.map((p) => [p.id, p.name]),
-            );
+            const personaNameMap = new Map(personas.map((p) => [p.id, p.name]));
             const participants = nextAiIds.map((id) => ({
                 id,
                 name: personaNameMap.get(id) ?? id,
@@ -756,14 +754,14 @@ function ParticipantsSidebar({
     );
     // Available to add: non-active, non-user personas not already the user's persona
     const availableToAdd = personas.filter(
-        (p) =>
+        (p): p is Persona & { id: string } =>
+            !!p.id &&
             !p.isUser &&
-            !participantSet.has(p.id ?? '') &&
+            !participantSet.has(p.id) &&
             p.id !== selectedPersonaId,
     );
     const userPersona = personas.find((p) => p.id === selectedPersonaId);
-    const totalActive =
-        activeParticipants.length + (userPersona ? 1 : 0);
+    const totalActive = activeParticipants.length + (userPersona ? 1 : 0);
 
     const decidingPhases = livePhases.filter((p) => p.phase === 'deciding');
 
@@ -836,8 +834,13 @@ function ParticipantsSidebar({
                             +
                         </button>
                         {showAddMenu && (
-                            <div ref={addMenuRef} className="member-add-dropdown">
-                                <div className="member-add-title">Add to chat</div>
+                            <div
+                                ref={addMenuRef}
+                                className="member-add-dropdown"
+                            >
+                                <div className="member-add-title">
+                                    Add to chat
+                                </div>
                                 {availableToAdd.length === 0 ? (
                                     <div className="member-add-empty">
                                         Everyone's here!
@@ -850,17 +853,18 @@ function ParticipantsSidebar({
                                                 type="button"
                                                 className="member-add-item"
                                                 onClick={() => {
-                                                    onAddParticipant(p.id!);
+                                                    onAddParticipant(p.id);
                                                     setShowAddMenu(false);
                                                 }}
                                             >
                                                 <img
-                                                    src={`https://robohash.org/${encodeURIComponent(p.id!)}?size=32x32`}
+                                                    src={`https://robohash.org/${encodeURIComponent(p.id)}?size=32x32`}
                                                     alt={p.name ?? ''}
                                                     style={{
                                                         width: 20,
                                                         height: 20,
-                                                        imageRendering: 'pixelated',
+                                                        imageRendering:
+                                                            'pixelated',
                                                     }}
                                                 />
                                                 <span>{p.name}</span>
@@ -915,9 +919,7 @@ function ParticipantsSidebar({
                                     <button
                                         type="button"
                                         className="member-action-btn remove"
-                                        onClick={() =>
-                                            onRemoveParticipant(id)
-                                        }
+                                        onClick={() => onRemoveParticipant(id)}
                                         disabled={isSaving}
                                         title="Remove from chat"
                                     >
@@ -974,7 +976,9 @@ function ParticipantsSidebar({
                     <span className="member-header-label">
                         Thought Log
                         {thoughtCount > 0 && (
-                            <span className="thought-badge">{thoughtCount}</span>
+                            <span className="thought-badge">
+                                {thoughtCount}
+                            </span>
                         )}
                     </span>
                     <span
@@ -1069,8 +1073,7 @@ function ParticipantsSidebar({
                                                 style={{
                                                     width: 13,
                                                     height: 13,
-                                                    imageRendering:
-                                                        'pixelated',
+                                                    imageRendering: 'pixelated',
                                                     flexShrink: 0,
                                                 }}
                                             />
@@ -1649,8 +1652,8 @@ function ConnectionDot({ status }: { status: RealtimeConnectionStatus }) {
     );
 }
 
-function formatTime(iso: string | null | undefined): string {
-    if (!iso) return '';
+function formatTime(iso: string | number | null | undefined): string {
+    if (iso == null || iso === '') return '';
     try {
         const d = new Date(iso);
         return d.toLocaleTimeString([], {

--- a/frontend/src/apps/chat-manager/GroupChatWindow.tsx
+++ b/frontend/src/apps/chat-manager/GroupChatWindow.tsx
@@ -8,11 +8,13 @@ import {
     getGetPartyIdChatGroupsQueryKey,
     useDeletePartyIdChatGroupsChatGroupIdMessagesAfterMessageId,
     useDeletePartyIdChatGroupsChatGroupIdMessagesMessageId,
+    useGetPartyIdChatGroupsSuspense,
     useGetPartyIdSuspense,
     usePostPartyIdCancel,
     usePostPartyIdProceed,
     usePostPartyIdPrompt,
     usePostPartyIdRepromptMessageId,
+    usePutPartyIdChatGroupsChatGroupIdParticipants,
     usePutPartyIdChatGroupsChatGroupIdScenario,
     usePutPartyIdParticipants,
 } from '../../api/party-zone';
@@ -76,13 +78,7 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
     const [inputValue, setInputValue] = useState('');
     const [selectedPersonaId, setSelectedPersonaId] = useState('');
 
-    // Participant management – backed by actual party state
-    const [participantPersonaIds, setParticipantPersonaIds] = useState<
-        string[]
-    >([]);
-    const [savedParticipantPersonaIds, setSavedParticipantPersonaIds] =
-        useState<string[]>([]);
-    const participantsInitialized = useRef(false);
+    const userPersonaInitialized = useRef(false);
     const lastSavedUserPersonaId = useRef<string | null>(null);
 
     const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -98,17 +94,31 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
         useRealtimeStoreActions();
 
     const partyDetailsQuery = useGetPartyIdSuspense(apiPartyId);
+    const chatGroupsQuery = useGetPartyIdChatGroupsSuspense(apiPartyId);
 
-    // Seed participant state from server data on first load
-    useEffect(() => {
-        if (participantsInitialized.current) return;
-        if (partyDetailsQuery.data.status !== 200) return;
-        const serverIds = (partyDetailsQuery.data.data.party.participants ?? [])
+    // Chat-group participants: server-owned, scoped to this chat group. AI-only subset.
+    const participantPersonaIds = useMemo(() => {
+        if (chatGroupsQuery.data.status !== 200) return [] as string[];
+        const group = chatGroupsQuery.data.data.find(
+            (g) => g.id === chatGroupId,
+        );
+        return (group?.participants ?? [])
             .filter((p) => !p.isUser && p.id)
             .map((p) => p.id as string);
-        setParticipantPersonaIds(serverIds);
-        setSavedParticipantPersonaIds(serverIds);
-        participantsInitialized.current = true;
+    }, [chatGroupsQuery.data, chatGroupId]);
+
+    // Init user persona from party roster on first load
+    useEffect(() => {
+        if (userPersonaInitialized.current) return;
+        if (partyDetailsQuery.data.status !== 200) return;
+        const userParticipant = (
+            partyDetailsQuery.data.data.party.participants ?? []
+        ).find((p) => p.isUser);
+        if (userParticipant?.id) {
+            setSelectedPersonaId(userParticipant.id);
+            lastSavedUserPersonaId.current = userParticipant.id;
+        }
+        userPersonaInitialized.current = true;
     }, [partyDetailsQuery.data]);
 
     const promptParty = usePostPartyIdPrompt();
@@ -151,21 +161,26 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
         target: textareaRef,
     });
 
-    const saveParticipantsMutation = usePutPartyIdParticipants({
+    const savePartyUserPersonaMutation = usePutPartyIdParticipants({
         mutation: {
-            onSuccess: (_data, variables) => {
-                const savedPersonaIds = (variables.data.participants ?? [])
-                    .filter((p) => !p.isUser && p.id !== null)
-                    .map(
-                        (p) => p.id ?? 'unreachable but tsc is being annoying',
-                    );
-                setSavedParticipantPersonaIds(savedPersonaIds);
+            onSuccess: () => {
                 queryClient.invalidateQueries({
                     queryKey: ['chat', 'party', apiPartyId],
                 });
             },
         },
     });
+
+    const saveChatGroupParticipantsMutation =
+        usePutPartyIdChatGroupsChatGroupIdParticipants({
+            mutation: {
+                onSuccess: () => {
+                    queryClient.invalidateQueries({
+                        queryKey: getGetPartyIdChatGroupsQueryKey(apiPartyId),
+                    });
+                },
+            },
+        });
 
     useEffect(() => {
         if (!chatGroupId) {
@@ -211,39 +226,35 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
         }
     }, [isNearBottom, unreadCount]);
 
-    // Keep selected persona in sync: auto-select first promptable persona if current selection is unavailable
+    // Keep selected persona valid: fall back to first available if current selection disappears
     useEffect(() => {
         if (partyDetailsQuery.data.status !== 200) return;
         const personas = partyDetailsQuery.data.data.personaParticipants;
-        const promptable = personas.filter(
-            (p) => !participantPersonaIds.includes(p.id ?? ''),
-        );
+        if (personas.length === 0) return;
         const isValid =
             selectedPersonaId &&
-            promptable.some((p) => p.id === selectedPersonaId);
+            personas.some((p) => p.id === selectedPersonaId);
         if (!isValid) {
-            setSelectedPersonaId(promptable[0]?.id ?? '');
+            setSelectedPersonaId(personas[0]?.id ?? '');
         }
-    }, [partyDetailsQuery.data, participantPersonaIds, selectedPersonaId]);
+    }, [partyDetailsQuery.data, selectedPersonaId]);
 
-    // Auto-save user persona to backend whenever selection changes
+    // Auto-save user persona to the party roster whenever selection changes.
+    // Preserves AI roster; only swaps the isUser:true entry.
     useEffect(() => {
+        if (!userPersonaInitialized.current) return;
         if (lastSavedUserPersonaId.current === selectedPersonaId) return;
         if (partyDetailsQuery.data.status !== 200) return;
-        if (!participantsInitialized.current) return;
 
         lastSavedUserPersonaId.current = selectedPersonaId;
 
+        const party = partyDetailsQuery.data.data.party;
         const personas = partyDetailsQuery.data.data.personaParticipants;
         const personaNameMap = new Map(personas.map((p) => [p.id, p.name]));
-        const aiParticipants = savedParticipantPersonaIds.map((id) => ({
-            id,
-            name: personaNameMap.get(id) ?? id,
-            isUser: false,
-        }));
+        const aiRoster = (party.participants ?? []).filter((p) => !p.isUser);
         const participants = selectedPersonaId
             ? [
-                  ...aiParticipants,
+                  ...aiRoster,
                   {
                       id: selectedPersonaId,
                       name:
@@ -252,26 +263,71 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
                       isUser: true,
                   },
               ]
-            : aiParticipants;
-        saveParticipantsMutation.mutate({
+            : aiRoster;
+        savePartyUserPersonaMutation.mutate({
             id: apiPartyId,
             data: { participants },
         });
     }, [
         selectedPersonaId,
         partyDetailsQuery.data,
-        savedParticipantPersonaIds,
         apiPartyId,
-        saveParticipantsMutation.mutate,
+        savePartyUserPersonaMutation.mutate,
     ]);
 
-    const hasParticipantChanges = useMemo(() => {
-        const a = new Set(participantPersonaIds);
-        const b = new Set(savedParticipantPersonaIds);
-        return (
-            a.size !== b.size || participantPersonaIds.some((id) => !b.has(id))
-        );
-    }, [participantPersonaIds, savedParticipantPersonaIds]);
+    const saveChatGroupParticipants = useCallback(
+        (nextAiIds: string[]) => {
+            if (partyDetailsQuery.data.status !== 200) return;
+            const personas = partyDetailsQuery.data.data.personaParticipants;
+            const personaNameMap = new Map(
+                personas.map((p) => [p.id, p.name]),
+            );
+            const participants = nextAiIds.map((id) => ({
+                id,
+                name: personaNameMap.get(id) ?? id,
+                isUser: false,
+            }));
+            saveChatGroupParticipantsMutation.mutate({
+                id: apiPartyId,
+                chatGroupId,
+                data: { participants },
+            });
+        },
+        [
+            partyDetailsQuery.data,
+            apiPartyId,
+            chatGroupId,
+            saveChatGroupParticipantsMutation.mutate,
+        ],
+    );
+
+    const addParticipant = useCallback(
+        (id: string) => {
+            if (participantPersonaIds.includes(id)) return;
+            saveChatGroupParticipants([...participantPersonaIds, id]);
+        },
+        [participantPersonaIds, saveChatGroupParticipants],
+    );
+
+    const removeParticipant = useCallback(
+        (id: string) => {
+            saveChatGroupParticipants(
+                participantPersonaIds.filter((pid) => pid !== id),
+            );
+        },
+        [participantPersonaIds, saveChatGroupParticipants],
+    );
+
+    const handleProceed = useCallback(() => {
+        if (busy) return;
+        proceedParty.mutateAsync({
+            id: apiPartyId,
+            data: {
+                chatGroupId,
+                senderId: selectedPersonaId || null,
+            },
+        });
+    }, [busy, proceedParty, apiPartyId, chatGroupId, selectedPersonaId]);
 
     const isStreaming = activeGenerations.length > 0;
     const activeGenerationSet = useMemo(
@@ -320,34 +376,7 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
         return respondedAfter ? null : lastInstruction;
     }, [uniqueMessages, selectedPersonaId]);
 
-    const handleSaveParticipants = useCallback(() => {
-        if (partyDetailsQuery.data.status !== 200) return;
-
-        const personas = partyDetailsQuery.data.data.personaParticipants;
-        const personaNameMap = new Map(personas.map((p) => [p.id, p.name]));
-        const userParticipants = (
-            partyDetailsQuery.data.data.party.participants ?? []
-        ).filter((p) => p.isUser);
-        const personasToSave = participantPersonaIds.map((id) => ({
-            id,
-            name: personaNameMap.get(id) ?? id,
-            isUser: false,
-        }));
-        saveParticipantsMutation.mutate({
-            id: apiPartyId,
-            data: { participants: [...personasToSave, ...userParticipants] },
-        });
-    }, [
-        apiPartyId,
-        participantPersonaIds,
-        partyDetailsQuery.data,
-        saveParticipantsMutation.mutate,
-    ]);
-
     const partyPersonas = partyDetailsQuery.data.data.personaParticipants;
-    const promptablePersonas = partyPersonas.filter(
-        (p) => !participantPersonaIds.includes(p.id ?? ''),
-    );
     const selectedPersonaName =
         partyPersonas.find((p) => p.id === selectedPersonaId)?.name ??
         selectedPersonaId;
@@ -624,32 +653,12 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
                                     )
                                 }
                             >
-                                {promptablePersonas.map((persona) => (
+                                {partyPersonas.map((persona) => (
                                     <option key={persona.id} value={persona.id}>
                                         {persona.name}
                                     </option>
                                 ))}
                             </select>
-                            <button
-                                type="button"
-                                disabled={busy}
-                                className="text-[11px]"
-                                style={{
-                                    padding: '2px 10px',
-                                    background: busy ? '#D4D0C8' : '#ECE9D8',
-                                }}
-                                onClick={() =>
-                                    proceedParty.mutateAsync({
-                                        id: apiPartyId,
-                                        data: {
-                                            chatGroupId,
-                                            senderId: selectedPersonaId || null,
-                                        },
-                                    })
-                                }
-                            >
-                                {busy ? '...' : 'Proceed'}
-                            </button>
                             <button
                                 type="submit"
                                 disabled={busy}
@@ -676,26 +685,11 @@ export function ChatView({ chatGroupId, partyName, scenario }: ChatViewProps) {
                 livePhases={generationPhases}
                 allMessages={uniqueMessages}
                 declinedDecisions={declinedDecisions}
-                hasChanges={hasParticipantChanges}
-                isSaving={saveParticipantsMutation.isPending}
-                saveError={
-                    saveParticipantsMutation.isError
-                        ? saveParticipantsMutation.error instanceof Error
-                            ? saveParticipantsMutation.error.message
-                            : 'Failed to save'
-                        : null
-                }
-                onToggleParticipant={(id) => {
-                    setParticipantPersonaIds((prev) =>
-                        prev.includes(id)
-                            ? prev.filter((pid) => pid !== id)
-                            : [...prev, id],
-                    );
-                }}
-                onSave={handleSaveParticipants}
-                onReset={() =>
-                    setParticipantPersonaIds(savedParticipantPersonaIds)
-                }
+                isSaving={saveChatGroupParticipantsMutation.isPending}
+                busy={busy}
+                onAddParticipant={addParticipant}
+                onRemoveParticipant={removeParticipant}
+                onProceed={handleProceed}
             />
         </div>
     );
@@ -710,12 +704,11 @@ function ParticipantsSidebar({
     livePhases,
     allMessages,
     declinedDecisions,
-    hasChanges,
     isSaving,
-    saveError,
-    onToggleParticipant,
-    onSave,
-    onReset,
+    busy,
+    onAddParticipant,
+    onRemoveParticipant,
+    onProceed,
 }: {
     personas: Persona[];
     participantPersonaIds: string[];
@@ -725,22 +718,55 @@ function ParticipantsSidebar({
     livePhases: ActiveGenerationPhase[];
     allMessages: RealtimeChatMessage[];
     declinedDecisions: DeclinedDecision[];
-    hasChanges: boolean;
     isSaving: boolean;
-    saveError: string | null;
-    onToggleParticipant: (id: string) => void;
-    onSave: () => void;
-    onReset: () => void;
+    busy: boolean;
+    onAddParticipant: (id: string) => void;
+    onRemoveParticipant: (id: string) => void;
+    onProceed: () => void;
 }) {
+    const [showAddMenu, setShowAddMenu] = useState(false);
+    const addMenuRef = useRef<HTMLDivElement>(null);
+    const addBtnRef = useRef<HTMLButtonElement>(null);
+    const [thoughtLogOpen, setThoughtLogOpen] = useState(true);
+
+    // Close add menu on outside click
+    useEffect(() => {
+        if (!showAddMenu) return;
+        const handler = (e: MouseEvent) => {
+            if (
+                addMenuRef.current &&
+                !addMenuRef.current.contains(e.target as Node) &&
+                addBtnRef.current &&
+                !addBtnRef.current.contains(e.target as Node)
+            ) {
+                setShowAddMenu(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [showAddMenu]);
+
     const participantSet = new Set(participantPersonaIds);
-    const aiPersonas = personas.filter((p) => !p.isUser);
+    // Only active AI participants (exclude user persona from AI list to prevent duplicate)
+    const activeParticipants = personas.filter(
+        (p) =>
+            !p.isUser &&
+            participantSet.has(p.id ?? '') &&
+            p.id !== selectedPersonaId,
+    );
+    // Available to add: non-active, non-user personas not already the user's persona
+    const availableToAdd = personas.filter(
+        (p) =>
+            !p.isUser &&
+            !participantSet.has(p.id ?? '') &&
+            p.id !== selectedPersonaId,
+    );
     const userPersona = personas.find((p) => p.id === selectedPersonaId);
     const totalActive =
-        participantPersonaIds.length + (selectedPersonaId ? 1 : 0);
+        activeParticipants.length + (userPersona ? 1 : 0);
 
     const decidingPhases = livePhases.filter((p) => p.phase === 'deciding');
 
-    // Combined thought log: "go" decisions from persisted messages + "skip" decisions captured at runtime
     const thoughtLog = useMemo(() => {
         type LogEntry = {
             key: string;
@@ -748,13 +774,10 @@ function ParticipantsSidebar({
             personaName: string;
             reason: string | null;
             instruction: string | null;
-            skip: boolean; // true = declined to respond
+            skip: boolean;
             sortKey: number;
         };
-
         const entries: LogEntry[] = [];
-
-        // "go" decisions: messages that have appraisalComplete (stop:false)
         for (const msg of allMessages) {
             if (!msg.appraisal) continue;
             try {
@@ -775,8 +798,6 @@ function ParticipantsSidebar({
                 /* ignore */
             }
         }
-
-        // "skip" decisions: captured from declined events (ephemeral, session-only)
         for (const d of declinedDecisions) {
             const persona = personas.find((p) => p.id === d.personaId);
             entries.push({
@@ -790,395 +811,294 @@ function ParticipantsSidebar({
                 sortKey: d.timestamp,
             });
         }
-
         return entries.sort((a, b) => b.sortKey - a.sortKey);
     }, [allMessages, declinedDecisions, personas]);
 
-    const sectionLabel = (text: string, badge?: number) => (
-        <div
-            style={{
-                padding: '4px 8px 2px',
-                fontSize: 10,
-                fontWeight: 700,
-                color: '#808080',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-            }}
-        >
-            {text}
-            {badge !== undefined && badge > 0 && (
-                <span
-                    style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        width: 14,
-                        height: 14,
-                        borderRadius: '50%',
-                        background: '#808080',
-                        color: '#fff',
-                        fontSize: 8,
-                        fontWeight: 700,
-                    }}
-                >
-                    {badge}
-                </span>
-            )}
-        </div>
-    );
+    const thoughtCount = decidingPhases.length + thoughtLog.length;
 
     return (
-        <div
-            className="participant-sidebar"
-            style={{
-                width: 180,
-                minWidth: 180,
-                height: '100%',
-                display: 'grid',
-                gridTemplateRows: 'auto 1fr',
-                overflow: 'hidden',
-            }}
-        >
-            {/* ── Participants section (auto height row) ── */}
-            <div style={{ overflow: 'hidden auto' }}>
-                {sectionLabel(`Participants — ${totalActive}`)}
-
-                {/* AI list */}
-                {aiPersonas.map((persona) => {
-                    const id = persona.id ?? '';
-                    const isActive = participantSet.has(id);
-                    const isWorking = activePersonaIds.has(id);
-                    const phase = personaPhases.get(id);
-                    const isDeciding = phase?.phase === 'deciding';
-
-                    return (
+        <div className="member-sidebar">
+            {/* ── Members section ── */}
+            <div className="member-section">
+                <div className="member-header">
+                    <span className="member-header-label">
+                        Members — {totalActive}
+                    </span>
+                    <div style={{ position: 'relative' }}>
                         <button
-                            key={id}
+                            ref={addBtnRef}
                             type="button"
-                            className={`participant-row w-full text-left${isActive ? ' active' : ''}`}
-                            onClick={() => onToggleParticipant(id)}
-                            title={
-                                isActive
-                                    ? 'Click to remove from chat'
-                                    : 'Click to add to chat'
-                            }
-                        >
-                            <img
-                                src={`https://robohash.org/${encodeURIComponent(id)}?size=32x32`}
-                                alt={persona.name ?? id}
-                                style={{
-                                    width: 24,
-                                    height: 24,
-                                    flexShrink: 0,
-                                    imageRendering: 'pixelated',
-                                }}
-                            />
-                            <span
-                                className={isWorking ? 'animate-pulse' : ''}
-                                style={{
-                                    flex: 1,
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                    fontSize: 11,
-                                    fontWeight: isActive ? 600 : 400,
-                                    color: isActive ? '#000' : '#808080',
-                                }}
-                            >
-                                {persona.name ?? id.slice(0, 8)}
-                            </span>
-                            {isDeciding ? (
-                                <span
-                                    className="animate-pulse"
-                                    style={{
-                                        fontSize: 8,
-                                        color: '#CC8800',
-                                        flexShrink: 0,
-                                    }}
-                                    title="Deciding whether to respond"
-                                >
-                                    ●
-                                </span>
-                            ) : (
-                                <span
-                                    className={`participant-status-dot${isActive ? ' online' : ' offline'}${isWorking ? ' working' : ''}`}
-                                />
-                            )}
-                        </button>
-                    );
-                })}
-
-                {/* User row */}
-                {userPersona && (
-                    <>
-                        <div
-                            style={{
-                                margin: '4px 8px 0',
-                                borderTop: '1px solid #D4D0C8',
-                            }}
-                        />
-                        <div className="participant-row active">
-                            <img
-                                src={`https://robohash.org/${encodeURIComponent(userPersona.name ?? selectedPersonaId)}?size=32x32&set=set5`}
-                                alt={userPersona.name ?? 'You'}
-                                style={{
-                                    width: 24,
-                                    height: 24,
-                                    flexShrink: 0,
-                                    imageRendering: 'pixelated',
-                                }}
-                            />
-                            <span
-                                style={{
-                                    flex: 1,
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                    fontSize: 11,
-                                    fontWeight: 600,
-                                    color: '#003399',
-                                }}
-                            >
-                                {userPersona.name ?? 'You'}
-                            </span>
-                            <span
-                                style={{
-                                    fontSize: 8,
-                                    color: '#808080',
-                                    flexShrink: 0,
-                                }}
-                            >
-                                you
-                            </span>
-                        </div>
-                    </>
-                )}
-
-                {/* Inline status / save controls */}
-                {participantPersonaIds.length === 0 &&
-                    aiPersonas.length > 0 && (
-                        <div
-                            style={{
-                                padding: '3px 8px',
-                                fontSize: 10,
-                                color: '#996600',
-                                background: '#FFFBEA',
-                                borderTop: '1px solid #E6D87A',
-                            }}
-                        >
-                            No AI participants — AI won't respond.
-                        </div>
-                    )}
-                {saveError && (
-                    <div
-                        style={{
-                            padding: '3px 8px',
-                            fontSize: 10,
-                            color: '#c00',
-                            borderTop: '1px solid #ACA899',
-                        }}
-                    >
-                        {saveError}
-                    </div>
-                )}
-                {hasChanges && (
-                    <div
-                        className="flex gap-1 p-1"
-                        style={{ borderTop: '1px solid #ACA899' }}
-                    >
-                        <button
-                            type="button"
+                            className="member-add-btn"
+                            onClick={() => setShowAddMenu((v) => !v)}
+                            title="Add participant"
                             disabled={isSaving}
-                            className="flex-1 text-[10px]"
-                            onClick={onReset}
                         >
-                            Reset
+                            +
                         </button>
-                        <button
-                            type="button"
-                            disabled={isSaving}
-                            className="flex-1 text-[10px]"
-                            onClick={onSave}
-                        >
-                            {isSaving ? 'Saving...' : 'Save'}
-                        </button>
+                        {showAddMenu && (
+                            <div ref={addMenuRef} className="member-add-dropdown">
+                                <div className="member-add-title">Add to chat</div>
+                                {availableToAdd.length === 0 ? (
+                                    <div className="member-add-empty">
+                                        Everyone's here!
+                                    </div>
+                                ) : (
+                                    <div className="member-add-list">
+                                        {availableToAdd.map((p) => (
+                                            <button
+                                                key={p.id}
+                                                type="button"
+                                                className="member-add-item"
+                                                onClick={() => {
+                                                    onAddParticipant(p.id!);
+                                                    setShowAddMenu(false);
+                                                }}
+                                            >
+                                                <img
+                                                    src={`https://robohash.org/${encodeURIComponent(p.id!)}?size=32x32`}
+                                                    alt={p.name ?? ''}
+                                                    style={{
+                                                        width: 20,
+                                                        height: 20,
+                                                        imageRendering: 'pixelated',
+                                                    }}
+                                                />
+                                                <span>{p.name}</span>
+                                            </button>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )}
                     </div>
-                )}
-            </div>
+                </div>
 
-            {/* ── Thought Log section (1fr grid row, always visible) ── */}
-            <div
-                style={{
-                    borderTop: '2px solid #ACA899',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflow: 'hidden',
-                }}
-            >
-                {sectionLabel(
-                    'Thought Log',
-                    decidingPhases.length + thoughtLog.length,
-                )}
+                {/* Active member rows */}
+                <div className="member-list">
+                    {activeParticipants.map((persona) => {
+                        const id = persona.id ?? '';
+                        const isWorking = activePersonaIds.has(id);
+                        const phase = personaPhases.get(id);
+                        const isDeciding = phase?.phase === 'deciding';
 
-                <div style={{ flex: 1, overflowY: 'auto' }}>
-                    {/* Live: personas currently deciding */}
-                    {decidingPhases.map((phase) => {
-                        const personaId = phase.personaName;
-                        const persona = personas.find(
-                            (p) => p.id === personaId,
-                        );
-                        const name = persona?.name ?? personaId?.slice(0, 8);
-                        const decisionText =
-                            phase.phase === 'deciding'
-                                ? phase.decisionText
-                                : '';
                         return (
-                            <div
-                                key={phase.messageId ?? personaId}
-                                style={{
-                                    borderBottom: '1px solid #E6D87A',
-                                    background: '#FFFBEA',
-                                    borderLeft: '3px solid #CC8800',
-                                    padding: '5px 8px',
-                                }}
-                            >
-                                <div className="flex items-center gap-1.5 mb-1">
+                            <div key={id} className="member-row group">
+                                <div className="member-avatar-wrap">
                                     <img
-                                        src={`https://robohash.org/${encodeURIComponent(personaId)}?size=32x32`}
-                                        alt={name}
+                                        src={`https://robohash.org/${encodeURIComponent(id)}?size=32x32`}
+                                        alt={persona.name ?? id}
                                         style={{
-                                            width: 14,
-                                            height: 14,
+                                            width: 26,
+                                            height: 26,
                                             imageRendering: 'pixelated',
-                                            flexShrink: 0,
                                         }}
                                     />
                                     <span
-                                        className="animate-pulse"
-                                        style={{
-                                            fontSize: 10,
-                                            fontWeight: 700,
-                                            color: '#806600',
-                                        }}
-                                    >
-                                        {name}…
-                                    </span>
+                                        className={`member-status-dot${isDeciding ? ' deciding' : isWorking ? ' working' : ' online'}`}
+                                    />
                                 </div>
-                                {decisionText && (
-                                    <div
-                                        style={{
-                                            fontSize: 9,
-                                            color: '#666',
-                                            fontFamily: 'monospace',
-                                            whiteSpace: 'pre-wrap',
-                                            wordBreak: 'break-all',
-                                            maxHeight: 100,
-                                            overflowY: 'auto',
-                                            lineHeight: 1.4,
-                                        }}
+                                <span
+                                    className={`member-name${isWorking ? ' animate-pulse' : ''}`}
+                                >
+                                    {persona.name ?? id.slice(0, 8)}
+                                </span>
+                                <span className="member-actions opacity-0 group-hover:opacity-100 transition-opacity">
+                                    <button
+                                        type="button"
+                                        className="member-action-btn proceed"
+                                        onClick={onProceed}
+                                        disabled={busy || isSaving}
+                                        title="Make them speak"
                                     >
-                                        {decisionText}
-                                    </div>
-                                )}
+                                        ▶
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="member-action-btn remove"
+                                        onClick={() =>
+                                            onRemoveParticipant(id)
+                                        }
+                                        disabled={isSaving}
+                                        title="Remove from chat"
+                                    >
+                                        ×
+                                    </button>
+                                </span>
                             </div>
                         );
                     })}
 
-                    {/* Settled decisions (go + skip), newest first */}
-                    {thoughtLog.length === 0 && decidingPhases.length === 0 ? (
-                        <div
-                            style={{
-                                padding: '10px 8px',
-                                fontSize: 10,
-                                color: '#ACA899',
-                                textAlign: 'center',
-                                lineHeight: 1.5,
-                            }}
-                        >
-                            No decisions yet
+                    {/* User persona — single entry, no actions */}
+                    {userPersona && (
+                        <>
+                            {activeParticipants.length > 0 && (
+                                <div className="member-divider" />
+                            )}
+                            <div className="member-row user-row">
+                                <div className="member-avatar-wrap">
+                                    <img
+                                        src={`https://robohash.org/${encodeURIComponent(userPersona.name ?? selectedPersonaId)}?size=32x32&set=set5`}
+                                        alt={userPersona.name ?? 'You'}
+                                        style={{
+                                            width: 26,
+                                            height: 26,
+                                            imageRendering: 'pixelated',
+                                        }}
+                                    />
+                                </div>
+                                <span className="member-name member-name-user">
+                                    {userPersona.name ?? 'You'}
+                                </span>
+                                <span className="member-you-badge">you</span>
+                            </div>
+                        </>
+                    )}
+
+                    {activeParticipants.length === 0 && (
+                        <div className="member-empty">
+                            No AI participants.
+                            <br />
+                            Click <strong>+</strong> to invite.
                         </div>
-                    ) : (
-                        thoughtLog.map((entry) => (
-                            <div
-                                key={entry.key}
-                                style={{
-                                    borderBottom: '1px solid #D4D0C8',
-                                    padding: '4px 8px',
-                                    borderLeft: entry.skip
-                                        ? '3px solid #CC8800'
-                                        : '3px solid #009900',
-                                }}
-                            >
-                                <div className="flex items-center gap-1.5">
-                                    {entry.personaId && (
+                    )}
+                </div>
+            </div>
+
+            {/* ── Thought Log section ── */}
+            <div className="thought-section">
+                <button
+                    type="button"
+                    className="member-header thought-header-btn"
+                    onClick={() => setThoughtLogOpen((v) => !v)}
+                >
+                    <span className="member-header-label">
+                        Thought Log
+                        {thoughtCount > 0 && (
+                            <span className="thought-badge">{thoughtCount}</span>
+                        )}
+                    </span>
+                    <span
+                        className="thought-chevron"
+                        style={{
+                            transform: thoughtLogOpen
+                                ? 'rotate(0deg)'
+                                : 'rotate(-90deg)',
+                        }}
+                    >
+                        ▾
+                    </span>
+                </button>
+
+                {thoughtLogOpen && (
+                    <div className="thought-entries">
+                        {/* Live: personas currently deciding */}
+                        {decidingPhases.map((phase) => {
+                            const personaId = phase.personaName;
+                            const persona = personas.find(
+                                (p) => p.id === personaId,
+                            );
+                            const name =
+                                persona?.name ?? personaId?.slice(0, 8);
+                            const decisionText =
+                                phase.phase === 'deciding'
+                                    ? phase.decisionText
+                                    : '';
+                            return (
+                                <div
+                                    key={phase.messageId ?? personaId}
+                                    className="thought-entry thought-deciding"
+                                >
+                                    <div className="flex items-center gap-1.5 mb-0.5">
                                         <img
-                                            src={`https://robohash.org/${encodeURIComponent(entry.personaId)}?size=32x32`}
-                                            alt={entry.personaName}
+                                            src={`https://robohash.org/${encodeURIComponent(personaId)}?size=32x32`}
+                                            alt={name}
                                             style={{
-                                                width: 13,
-                                                height: 13,
+                                                width: 14,
+                                                height: 14,
                                                 imageRendering: 'pixelated',
                                                 flexShrink: 0,
                                             }}
                                         />
+                                        <span
+                                            className="animate-pulse"
+                                            style={{
+                                                fontSize: 10,
+                                                fontWeight: 700,
+                                                color: '#806600',
+                                            }}
+                                        >
+                                            {name}…
+                                        </span>
+                                    </div>
+                                    {decisionText && (
+                                        <div
+                                            style={{
+                                                fontSize: 9,
+                                                color: '#666',
+                                                fontFamily: 'monospace',
+                                                whiteSpace: 'pre-wrap',
+                                                wordBreak: 'break-all',
+                                                maxHeight: 80,
+                                                overflowY: 'auto',
+                                                lineHeight: 1.3,
+                                            }}
+                                        >
+                                            {decisionText}
+                                        </div>
                                     )}
-                                    <span
-                                        style={{
-                                            fontSize: 10,
-                                            fontWeight: 600,
-                                            color: '#333',
-                                            flex: 1,
-                                            overflow: 'hidden',
-                                            textOverflow: 'ellipsis',
-                                            whiteSpace: 'nowrap',
-                                        }}
-                                    >
-                                        {entry.personaName}
-                                    </span>
-                                    <span
-                                        style={{
-                                            fontSize: 9,
-                                            color: entry.skip
-                                                ? '#CC8800'
-                                                : '#009900',
-                                            fontWeight: 700,
-                                            flexShrink: 0,
-                                        }}
-                                    >
-                                        {entry.skip ? 'skip' : 'go'}
-                                    </span>
                                 </div>
-                                {entry.reason && (
-                                    <div
-                                        style={{
-                                            fontSize: 9,
-                                            color: '#666',
-                                            fontStyle: 'italic',
-                                            lineHeight: 1.3,
-                                            marginTop: 1,
-                                        }}
-                                    >
-                                        {entry.reason}
-                                    </div>
-                                )}
-                                {entry.instruction && entry.skip && (
-                                    <div
-                                        style={{
-                                            fontSize: 9,
-                                            color: '#806600',
-                                            lineHeight: 1.3,
-                                        }}
-                                    >
-                                        → {entry.instruction}
-                                    </div>
-                                )}
+                            );
+                        })}
+
+                        {thoughtLog.length === 0 &&
+                        decidingPhases.length === 0 ? (
+                            <div className="thought-empty">
+                                No decisions yet
                             </div>
-                        ))
-                    )}
-                </div>
+                        ) : (
+                            thoughtLog.map((entry) => (
+                                <div
+                                    key={entry.key}
+                                    className={`thought-entry ${entry.skip ? 'thought-skip' : 'thought-go'}`}
+                                >
+                                    <div className="flex items-center gap-1.5">
+                                        {entry.personaId && (
+                                            <img
+                                                src={`https://robohash.org/${encodeURIComponent(entry.personaId)}?size=32x32`}
+                                                alt={entry.personaName}
+                                                style={{
+                                                    width: 13,
+                                                    height: 13,
+                                                    imageRendering:
+                                                        'pixelated',
+                                                    flexShrink: 0,
+                                                }}
+                                            />
+                                        )}
+                                        <span className="thought-name">
+                                            {entry.personaName}
+                                        </span>
+                                        <span
+                                            className={`thought-verdict ${entry.skip ? 'skip' : 'go'}`}
+                                        >
+                                            {entry.skip ? 'skip' : 'go'}
+                                        </span>
+                                    </div>
+                                    {entry.reason && (
+                                        <div className="thought-reason">
+                                            {entry.reason}
+                                        </div>
+                                    )}
+                                    {entry.instruction && entry.skip && (
+                                        <div className="thought-instruction">
+                                            → {entry.instruction}
+                                        </div>
+                                    )}
+                                </div>
+                            ))
+                        )}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/apps/config-panel/ConfigPanelApp.tsx
+++ b/frontend/src/apps/config-panel/ConfigPanelApp.tsx
@@ -434,7 +434,11 @@ function LlmProvidersSection() {
                     title={isNew ? 'Add Provider' : 'Edit Provider'}
                     onClose={close}
                 >
-                    <ProviderEditor entry={editing} isNew={isNew} onClose={close} />
+                    <ProviderEditor
+                        entry={editing}
+                        isNew={isNew}
+                        onClose={close}
+                    />
                 </ProviderModal>
             )}
         </div>
@@ -744,7 +748,6 @@ function ProviderEditor({
 
     return (
         <div>
-
             {/* Type */}
             <FormRow label="Type">
                 <select
@@ -848,11 +851,7 @@ function ProviderEditor({
                 >
                     {isPending ? 'Saving...' : 'Save'}
                 </button>
-                <button
-                    type="button"
-                    onClick={onClose}
-                    disabled={isPending}
-                >
+                <button type="button" onClick={onClose} disabled={isPending}>
                     Cancel
                 </button>
             </div>

--- a/frontend/src/lib/realtime-store.ts
+++ b/frontend/src/lib/realtime-store.ts
@@ -174,9 +174,10 @@ export const useRealtimeStore = create<RealtimeStoreState>((set, get) => {
                 const envelope = JSON.parse(
                     event.data,
                 ) as PartyRealtimeEnvelope;
+                console.log('[ws]', envelope.type, envelope.data);
                 handleEnvelope(partyId, envelope);
-            } catch {
-                // Ignore malformed payloads.
+            } catch (err) {
+                console.warn('[ws] parse error', err, event.data);
             }
         });
 

--- a/frontend/src/lib/realtime-store.ts
+++ b/frontend/src/lib/realtime-store.ts
@@ -494,8 +494,7 @@ export const useRealtimeStore = create<RealtimeStoreState>((set, get) => {
                         /* ignore */
                     }
                     const declined: DeclinedDecision = {
-                        personaId:
-                            declinedPersonaId || phantom?.senderId || '',
+                        personaId: declinedPersonaId || phantom?.senderId || '',
                         reason: declinedReason,
                         decisionText: (phantom?.appraisal ?? '').trim(),
                         timestamp: Date.now(),

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,7 +1,7 @@
+import { QueryClient } from '@tanstack/react-query';
 import { createRouter, ErrorComponent } from '@tanstack/react-router';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
 import { routeTree } from './routeTree.gen';
-import { QueryClient } from '@tanstack/react-query';
 
 export function getRouter() {
     const queryClient = new QueryClient();

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { useDesktopStore } from '../lib/desktop-context';
 import { desktopLayoutSchema } from '../types/desktop';
 import DesktopExperience from '../views/DesktopExperience';
-import { useDesktopStore } from '../lib/desktop-context';
-import { useEffect } from 'react';
 
 export const Route = createFileRoute('/')({
     validateSearch: desktopLayoutSchema,

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -1,5 +1,6 @@
 import handler, { createServerEntry } from '@tanstack/react-start/server-entry';
 import { FastResponse } from 'srvx';
+
 globalThis.Response = FastResponse;
 
 const serverEntry = createServerEntry({

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -82,54 +82,182 @@ body {
     background: #fff;
 }
 
-/* Participant sidebar */
-.participant-sidebar {
+/* ── Member sidebar (Discord-style member list, XP chrome) ── */
+.member-sidebar {
+    width: 200px;
+    min-width: 200px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     background: linear-gradient(180deg, #f5f5ed 0%, #ece9d8 100%);
     border-left: 1px solid #aca899;
+    overflow: hidden;
 }
 
-.participant-row {
+.member-section {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.member-header {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 4px 8px;
-    cursor: pointer;
-    border: none;
-    background: transparent;
-    width: 100%;
-    text-align: left;
-}
-
-.participant-row:hover {
-    background: rgba(49, 106, 197, 0.08);
-}
-
-.participant-row.active {
-    background: rgba(49, 106, 197, 0.06);
-}
-
-.participant-row.active:hover {
-    background: rgba(49, 106, 197, 0.12);
-}
-
-.participant-status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    margin-left: auto;
+    justify-content: space-between;
+    padding: 6px 8px 4px;
+    border-bottom: 1px solid #d4d0c8;
     flex-shrink: 0;
 }
 
-.participant-status-dot.online {
+.member-header-label {
+    font-size: 10px;
+    font-weight: 700;
+    color: #808080;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.member-add-btn {
+    width: 20px;
+    height: 20px;
+    border: 1px solid #aca899;
+    background: linear-gradient(180deg, #fff 0%, #ece9d8 100%);
+    font-size: 14px;
+    font-weight: 700;
+    color: #316ac5;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+}
+
+.member-add-btn:hover {
+    background: linear-gradient(180deg, #fff 0%, #d6e4f9 100%);
+    border-color: #316ac5;
+}
+
+.member-add-btn:disabled {
+    color: #aca899;
+    cursor: default;
+}
+
+/* Add member dropdown (XP menu style) */
+.member-add-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 2px;
+    min-width: 180px;
+    max-height: 240px;
+    background: #fff;
+    border: 1px solid #404040;
+    box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.25);
+    z-index: 100;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.member-add-title {
+    padding: 4px 8px;
+    font-size: 10px;
+    font-weight: 700;
+    color: #808080;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    border-bottom: 1px solid #d4d0c8;
+    background: #f5f5ed;
+}
+
+.member-add-list {
+    overflow-y: auto;
+}
+
+.member-add-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 4px 8px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 11px;
+    color: #000;
+    text-align: left;
+}
+
+.member-add-item:hover {
+    background: #316ac5;
+    color: #fff;
+}
+
+.member-add-empty {
+    padding: 12px 8px;
+    font-size: 10px;
+    color: #808080;
+    text-align: center;
+}
+
+/* Member list (scrollable) */
+.member-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 2px 0;
+}
+
+/* Individual member row */
+.member-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 3px 8px;
+    position: relative;
+}
+
+.member-row:hover {
+    background: rgba(49, 106, 197, 0.08);
+}
+
+.member-row.user-row {
+    padding: 4px 8px;
+}
+
+.member-avatar-wrap {
+    position: relative;
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+}
+
+.member-status-dot {
+    position: absolute;
+    bottom: -1px;
+    right: -1px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 2px solid #ece9d8;
+}
+
+.member-status-dot.online {
     background: #00aa00;
 }
 
-.participant-status-dot.offline {
-    background: #c0c0c0;
+.member-status-dot.working {
+    background: #00aa00;
+    animation: pulse-dot 1.2s ease-in-out infinite;
 }
 
-.participant-status-dot.working {
+.member-status-dot.deciding {
+    background: #cc8800;
     animation: pulse-dot 1.2s ease-in-out infinite;
 }
 
@@ -143,6 +271,194 @@ body {
         opacity: 0.5;
         transform: scale(1.3);
     }
+}
+
+.member-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 11px;
+    font-weight: 600;
+    color: #000;
+}
+
+.member-name-user {
+    color: #003399;
+}
+
+/* Per-member hover actions */
+.member-actions {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+.member-action-btn {
+    width: 18px;
+    height: 18px;
+    border: 1px solid transparent;
+    background: transparent;
+    font-size: 10px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    color: #808080;
+    border-radius: 2px;
+}
+
+.member-action-btn:hover {
+    border-color: #aca899;
+    background: #fff;
+}
+
+.member-action-btn.proceed:hover {
+    color: #316ac5;
+}
+
+.member-action-btn.remove:hover {
+    color: #cc0000;
+}
+
+.member-action-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.member-divider {
+    margin: 3px 8px;
+    border-top: 1px solid #d4d0c8;
+}
+
+.member-you-badge {
+    font-size: 9px;
+    color: #808080;
+    flex-shrink: 0;
+    padding: 1px 4px;
+    background: rgba(49, 106, 197, 0.08);
+    border-radius: 2px;
+}
+
+.member-empty {
+    padding: 12px 8px;
+    font-size: 10px;
+    color: #aca899;
+    text-align: center;
+    line-height: 1.6;
+}
+
+/* ── Thought Log section ── */
+.thought-section {
+    border-top: 1px solid #aca899;
+    display: flex;
+    flex-direction: column;
+    max-height: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.thought-header-btn {
+    width: 100%;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    text-align: left;
+}
+
+.thought-header-btn:hover {
+    background: rgba(49, 106, 197, 0.06);
+}
+
+.thought-chevron {
+    font-size: 10px;
+    color: #808080;
+    transition: transform 0.15s ease;
+}
+
+.thought-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    background: #808080;
+    color: #fff;
+    font-size: 8px;
+    font-weight: 700;
+    padding: 0 3px;
+}
+
+.thought-entries {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.thought-entry {
+    padding: 4px 8px;
+    border-bottom: 1px solid #d4d0c8;
+}
+
+.thought-deciding {
+    background: #fffbea;
+    border-left: 3px solid #cc8800;
+    border-bottom-color: #e6d87a;
+}
+
+.thought-skip {
+    border-left: 3px solid #cc8800;
+}
+
+.thought-go {
+    border-left: 3px solid #009900;
+}
+
+.thought-name {
+    font-size: 10px;
+    font-weight: 600;
+    color: #333;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.thought-verdict {
+    font-size: 9px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.thought-verdict.skip {
+    color: #cc8800;
+}
+
+.thought-verdict.go {
+    color: #009900;
+}
+
+.thought-reason {
+    font-size: 9px;
+    color: #666;
+    font-style: italic;
+    line-height: 1.3;
+    margin-top: 1px;
+}
+
+.thought-instruction {
+    font-size: 9px;
+    color: #806600;
+    line-height: 1.3;
+}
+
+.thought-empty {
+    padding: 10px 8px;
+    font-size: 10px;
+    color: #aca899;
+    text-align: center;
 }
 
 /* Markdown rendered content inside chat bubbles */

--- a/frontend/src/views/DesktopExperience.tsx
+++ b/frontend/src/views/DesktopExperience.tsx
@@ -1,4 +1,4 @@
-import { useMemo, createElement } from 'react';
+import { createElement, useMemo } from 'react';
 import GridLayout from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import DesktopIcon from '../components/desktop/DesktopIcon';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import fs from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';


### PR DESCRIPTION
## Summary

- Participants are now scoped to individual chat groups instead of shared across the whole party. Each chat group has its own invite list drawn from the party roster.
- New Discord-style member sidebar: active members only, `+` to invite from the roster, per-member hover actions (speak / remove).
- Duplicate "you"/AI entry fixed — the selected user persona is shown once at the bottom, never alongside the AI list.
- Proceed moved from the input bar into a per-member "speak" action.
- Persona creation auto-adds the persona to the default party roster; persona delete cascades through the party and into every chat group.

## Backend changes

- `ChatGroupInfo.Participants` hydrated at the API boundary from `ChatGroupGrain` (not persisted on `PartyState`).
- New endpoint `PUT /Party/{id}/chat-groups/{chatGroupId}/participants` with validation that ids are a subset of the party roster.
- `PartyGrain.SetParticipants` no longer broadcasts the full list to chat groups — only cascades removals, so deleted personas leave every chat but additions don't auto-invite.
- `PersonaController.Upsert` auto-adds new personas to the default party roster; `Remove` cascades to party + chat groups.
- `ChatGroupGrain.SetParticipantsAsync` publishes a realtime `chatGroupParticipants` event (no frontend handler yet — query invalidation covers the current session).

## Frontend changes

- `ChatView` now derives chat-group participants from `useGetPartyIdChatGroupsSuspense` and saves via the new chat-group endpoint.
- User persona stays at party level; AI roster lives per chat group.
- New sidebar CSS (`.member-*`, `.thought-*`) replacing the old `.participant-*` styles.
- Orval-regenerated API client (`party-zone.ts`, `chatGroupInfo.ts`).

## Test plan

- [x] Open an existing chat group — only currently-invited personas appear in the member list.
- [x] Click `+` — dropdown lists remaining personas from the party roster.
- [x] Invite a persona — they appear in the sidebar, a message prompt notifies them.
- [x] Remove a persona — they disappear from this chat only; other chat groups unaffected.
- [x] Hover a member, click ▶ — proceed fires, that persona (or whoever the overseer picks) responds.
- [x] Switch user persona — user row updates, AI roster stays intact across all chats.
- [x] Create a new persona via the Personas app — appears in the `+` dropdown of every chat group, but not auto-added to existing chats.
- [x] Delete a persona — removed from all chat groups.
- [x] Create a new chat group — inherits the current party roster as its initial invite list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Members sidebar with add/remove member controls and per-member actions.
  * Thought Log panel showing persona decisions and reasoning.
  * API endpoint to manage chat-group participant rosters.

* **Improvements**
  * Persisted, server-driven chat-group participant lists and improved sync when members are removed.
  * More informative error responses for config operations.
  * Console warnings/logs for realtime message parsing issues.

* **Documentation**
  * Clarified development hot-reload instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->