### PR TITLE
feat(storybook): wire up Storybook MCP for AI agents

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+    "mcpServers": {
+        "proompting-sb": {
+            "type": "http",
+            "url": "http://localhost:6006/mcp"
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,14 @@ DB init scripts in `docker-entrypoint-initdb.d/`. Re-run: wipe volume (`docker c
 
 **Code style:** Biome for linting/formatting — 4-space indent, single quotes, trailing commas. No Prettier/ESLint.
 
+**Storybook + MCP:** Stories live next to components (`*.stories.tsx`). Run `npm run storybook` (port 6006). Module mocks for app deps (`#api/party-zone`, `#lib/realtime-store`, etc.) are wired via `package.json` `imports` — point new mocks there.
+
+The `@storybook/addon-mcp` addon exposes a Model Context Protocol server at `http://localhost:6006/mcp` (registered for Claude Code via `.mcp.json` as `proompting-sb`). When working on UI:
+- Call `proompting-sb` tools (`list-all-documentation`, `get-documentation`, `get-documentation-for-story`) to discover existing components/stories before writing new UI.
+- Call `get-storybook-story-instructions` before authoring a new `.stories.tsx`.
+- Use `preview-stories` to render existing stories instead of guessing what they look like.
+Storybook must be running for the MCP server to respond.
+
 ### Infrastructure
 
 - **Caddy** reverse proxy routes API traffic to backend

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,7 @@ services:
         ports:
             - "3000:3000"
             - "5173:5173"
+            - "6006:6006"
             - "42069:42069"
         volumes:
             - ./frontend:/app:delegated

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -7,7 +7,7 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    addons: [],
+    addons: ['@storybook/addon-mcp'],
     typescript: {
         reactDocgen: 'react-docgen',
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
             },
             "devDependencies": {
                 "@biomejs/biome": "2.2.4",
+                "@storybook/addon-mcp": "^0.6.0",
                 "@storybook/react-vite": "^10.3.5",
                 "@tanstack/devtools-vite": "0.6.0",
                 "@tanstack/react-router-ssr-query": "^1.166.10",
@@ -1754,6 +1755,52 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@storybook/addon-mcp": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-mcp/-/addon-mcp-0.6.0.tgz",
+            "integrity": "sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/mcp": "0.7.0",
+                "@tmcp/adapter-valibot": "^0.1.5",
+                "@tmcp/transport-http": "^0.8.5",
+                "picoquery": "^2.5.0",
+                "tmcp": "^1.19.3",
+                "valibot": "1.2.0"
+            },
+            "peerDependencies": {
+                "@storybook/addon-vitest": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0",
+                "storybook": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@storybook/addon-vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@storybook/addon-mcp/node_modules/valibot": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+            "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "typescript": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@storybook/builder-vite": {
             "version": "10.3.5",
             "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.5.tgz",
@@ -1824,6 +1871,34 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@storybook/mcp": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@storybook/mcp/-/mcp-0.7.0.tgz",
+            "integrity": "sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tmcp/adapter-valibot": "^0.1.5",
+                "@tmcp/transport-http": "^0.8.5",
+                "tmcp": "^1.19.3",
+                "valibot": "1.2.0"
+            }
+        },
+        "node_modules/@storybook/mcp/node_modules/valibot": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+            "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "typescript": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@storybook/react": {
@@ -2894,6 +2969,49 @@
                 "@testing-library/dom": ">=7.21.4"
             }
         },
+        "node_modules/@tmcp/adapter-valibot": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@tmcp/adapter-valibot/-/adapter-valibot-0.1.5.tgz",
+            "integrity": "sha512-9P2wrVYPngemNK0UvPb/opC722/jfd09QxXmme1TRp/wPsl98vpSk/MXt24BCMqBRv4Dvs0xxJH4KHDcjXW52Q==",
+            "dev": true,
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@valibot/to-json-schema": "^1.3.0",
+                "valibot": "^1.1.0"
+            },
+            "peerDependencies": {
+                "tmcp": "^1.17.0",
+                "valibot": "^1.1.0"
+            }
+        },
+        "node_modules/@tmcp/session-manager": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@tmcp/session-manager/-/session-manager-0.2.1.tgz",
+            "integrity": "sha512-DOGy9LfufXCy1wfpGHZ6qPSDQtRnTVwOb71+41ffovTqzLMZlK3iLK/LIsekHxIiku+iIAUiqEKN+DHbqEm8IA==",
+            "dev": true,
+            "peerDependencies": {
+                "tmcp": "^1.16.3"
+            }
+        },
+        "node_modules/@tmcp/transport-http": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/@tmcp/transport-http/-/transport-http-0.8.5.tgz",
+            "integrity": "sha512-qQLqiCTtbxtTSswqOn/782df7O57RxI/yLUtCDQ++kHEhbmDUc8glmmtGJ3mrb7yPSPoM5VF2Pc2Q5cA6quzLA==",
+            "dev": true,
+            "dependencies": {
+                "@tmcp/session-manager": "^0.2.1",
+                "esm-env": "^1.2.2"
+            },
+            "peerDependencies": {
+                "@tmcp/auth": "^0.3.3 || ^0.4.0",
+                "tmcp": "^1.18.0"
+            },
+            "peerDependenciesMeta": {
+                "@tmcp/auth": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3057,6 +3175,16 @@
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@valibot/to-json-schema": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.6.0.tgz",
+            "integrity": "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "valibot": "^1.3.0"
+            }
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "6.0.1",
@@ -4002,6 +4130,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/esm-env": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+            "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4658,6 +4793,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/json-rpc-2.0": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+            "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -5525,6 +5667,13 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/picoquery": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/picoquery/-/picoquery-2.5.0.tgz",
+            "integrity": "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/postcss": {
             "version": "8.5.8",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -6106,6 +6255,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/sqids": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/sqids/-/sqids-0.3.0.tgz",
+            "integrity": "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/srvx": {
             "version": "0.11.15",
             "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.15.tgz",
@@ -6308,6 +6464,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tmcp": {
+            "version": "1.19.3",
+            "resolved": "https://registry.npmjs.org/tmcp/-/tmcp-1.19.3.tgz",
+            "integrity": "sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "json-rpc-2.0": "^1.7.1",
+                "sqids": "^0.3.0",
+                "uri-template-matcher": "^1.1.1",
+                "valibot": "^1.1.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -6553,6 +6723,13 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
+        },
+        "node_modules/uri-template-matcher": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/uri-template-matcher/-/uri-template-matcher-1.1.2.tgz",
+            "integrity": "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/use-sync-external-store": {
             "version": "1.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
         "lint": "biome lint --write",
         "check": "biome check",
         "api-generate": "orval",
-        "storybook": "storybook dev -p 6006",
+        "storybook": "storybook dev -p 6006 --host 0.0.0.0",
         "build-storybook": "storybook build"
     },
     "dependencies": {
@@ -62,6 +62,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "2.2.4",
+        "@storybook/addon-mcp": "^0.6.0",
         "@storybook/react-vite": "^10.3.5",
         "@tanstack/devtools-vite": "0.6.0",
         "@tanstack/react-router-ssr-query": "^1.166.10",


### PR DESCRIPTION
## Summary
- Adds `@storybook/addon-mcp` so Storybook exposes a Model Context Protocol server at `http://localhost:6006/mcp`, letting Claude Code (and other agents) introspect stories/components instead of grepping
- Registers the server as `proompting-sb` via root-level `.mcp.json`
- Exposes port 6006 on the dev-frontend container and binds storybook to `0.0.0.0` so the server is reachable from the host
- Documents the new MCP tools (`list-all-documentation`, `get-documentation`, `get-storybook-story-instructions`, `preview-stories`) in `CLAUDE.md`

## Test plan
- [ ] Rebuild the frontend dev container (or `docker compose exec dev-frontend npm install`) so the new addon is present
- [ ] `docker compose exec dev-frontend npm run storybook` and confirm http://localhost:6006 loads
- [ ] `curl -X POST http://localhost:6006/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'` returns the addon-mcp tool list
- [ ] In Claude Code, run `/mcp` and confirm `proompting-sb` is connected; call `list-all-documentation` and verify it enumerates the existing stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Storybook with MCP server support for enhanced component discovery and interaction.
  * Exposed Storybook service on port 6006 for external access.

* **Documentation**
  * Added guide for structuring stories and using Storybook with MCP workflows.

* **Chores**
  * Updated configuration for Storybook network accessibility and MCP addon integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->