### PR TITLE
feat(daccord): create-room modal w/ title + scenario

### DIFF
--- a/frontend/src/apps/daccord/DaccordApp.tsx
+++ b/frontend/src/apps/daccord/DaccordApp.tsx
@@ -14,6 +14,7 @@ import { useWindowInstance } from '../../components/desktop/window-instance-cont
 import { useSetWindowTitleBar } from '../../components/desktop/window-titlebar-context';
 import { ROOT_PARTY_ID } from '../../lib/chat-api';
 import { useDesktopContext, useDesktopStore } from '../../lib/desktop-context';
+import CreateRoomDialog from './components/CreateRoomDialog';
 import DaccordSearchBar from './components/DaccordSearchBar';
 import DaccordSidebar from './components/DaccordSidebar';
 import DiscoverFeed from './components/DiscoverFeed';
@@ -64,8 +65,7 @@ export default function DaccordApp() {
 
     const [searchQuery, setSearchQuery] = useState('');
     const [activeCategory, setActiveCategory] = useState('home');
-    const [newChatName, setNewChatName] = useState('');
-    const [newChatScenario, setNewChatScenario] = useState('');
+    const [createOpen, setCreateOpen] = useState(false);
 
     const { connectPartyRealtime, disconnectPartyRealtime } =
         useRealtimeStoreActions();
@@ -80,7 +80,7 @@ export default function DaccordApp() {
     const chatGroups = useMemo(() => {
         const raw = chatGroupsQuery.data?.data;
         if (!Array.isArray(raw)) return [];
-        return raw.flatMap((g) =>
+        const mapped = raw.flatMap((g) =>
             g.id && g.name
                 ? [
                       {
@@ -92,6 +92,9 @@ export default function DaccordApp() {
                   ]
                 : [],
         );
+        const ts = (v: string | number | null) =>
+            v == null ? 0 : new Date(v).getTime() || 0;
+        return mapped.sort((a, b) => ts(b.createdAt) - ts(a.createdAt));
     }, [chatGroupsQuery.data?.data]);
 
     const createMutation = usePostPartyIdChatGroups({
@@ -100,14 +103,29 @@ export default function DaccordApp() {
                 queryClient.invalidateQueries({
                     queryKey: getGetPartyIdChatGroupsQueryKey(ROOT_PARTY_ID),
                 });
+                setCreateOpen(false);
                 if (created.data.id) {
                     enterRoom(created.data.id, false);
                 }
-                setNewChatName('');
-                setNewChatScenario('');
             },
         },
     });
+
+    const handleCreateRoom = useCallback(
+        (name: string, scenario: string) => {
+            createMutation.mutate({
+                id: ROOT_PARTY_ID,
+                data: { name, scenario: scenario || null },
+            });
+        },
+        [createMutation],
+    );
+
+    const createErrorMessage = createMutation.isError
+        ? createMutation.error instanceof Error
+            ? createMutation.error.message
+            : 'Failed to create room.'
+        : null;
 
     // Push search bar into the window title bar (only when on the hub view).
     const titleBarNode = useMemo(() => {
@@ -118,10 +136,20 @@ export default function DaccordApp() {
     }, [view.kind, searchQuery]);
     useSetWindowTitleBar(titleBarNode);
 
+    const dialog = (
+        <CreateRoomDialog
+            open={createOpen}
+            creating={createMutation.isPending}
+            errorMessage={createErrorMessage}
+            onClose={() => setCreateOpen(false)}
+            onSubmit={handleCreateRoom}
+        />
+    );
+
     if (view.kind === 'room') {
         const selected = chatGroups.find((g) => g.id === view.chatGroupId);
         return (
-            <div className="app-surface no-xp-buttons @container flex h-full overflow-hidden bg-white dark:bg-slate-900">
+            <div className="app-surface no-xp-buttons @container relative flex h-full overflow-hidden bg-white dark:bg-slate-900">
                 <DaccordSidebar
                     realRooms={chatGroups.map((g) => ({
                         id: g.id,
@@ -131,6 +159,7 @@ export default function DaccordApp() {
                     activeRoomId={view.chatGroupId}
                     activeCategory={activeCategory}
                     onSelectCategory={setActiveCategory}
+                    onCreateRoom={() => setCreateOpen(true)}
                 />
                 <main className="flex flex-1 min-w-0 flex-col bg-gradient-to-b from-slate-50 via-white to-blue-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950">
                     {/* Glass header — back button + room title */}
@@ -169,17 +198,19 @@ export default function DaccordApp() {
                         </div>
                     </div>
                 </main>
+                {dialog}
             </div>
         );
     }
 
     return (
-        <div className="app-surface no-xp-buttons @container flex h-full overflow-hidden bg-white dark:bg-slate-900">
+        <div className="app-surface no-xp-buttons @container relative flex h-full overflow-hidden bg-white dark:bg-slate-900">
             <DaccordSidebar
                 realRooms={chatGroups.map((g) => ({ id: g.id, name: g.name }))}
                 onSelectRoom={(id) => enterRoom(id, false)}
                 activeCategory={activeCategory}
                 onSelectCategory={setActiveCategory}
+                onCreateRoom={() => setCreateOpen(true)}
             />
             <main className="flex flex-1 min-w-0 flex-col bg-gradient-to-b from-slate-50 via-white to-blue-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950">
                 <div className="flex items-center justify-between px-4 py-2">
@@ -191,31 +222,15 @@ export default function DaccordApp() {
                         <span className="capitalize">{connectionStatus}</span>
                     </div>
                 </div>
-                {createMutation.isError && (
-                    <div className="bg-red-100 dark:bg-red-950 px-4 py-1.5 text-xs text-red-700 dark:text-red-300">
-                        {createMutation.error instanceof Error
-                            ? createMutation.error.message
-                            : 'Failed to create room.'}
-                    </div>
-                )}
                 <DiscoverFeed
                     realRooms={chatGroups}
-                    onCreateRoom={(name, scenario) =>
-                        createMutation.mutate({
-                            id: ROOT_PARTY_ID,
-                            data: { name, scenario: scenario || null },
-                        })
-                    }
-                    creating={createMutation.isPending}
                     searchQuery={searchQuery}
                     onSelectRealRoom={(id) => enterRoom(id, false)}
-                    inputName={newChatName}
-                    inputScenario={newChatScenario}
-                    onInputName={setNewChatName}
-                    onInputScenario={setNewChatScenario}
+                    onOpenCreate={() => setCreateOpen(true)}
                 />
             </main>
             <ProfilePanel />
+            {dialog}
         </div>
     );
 }

--- a/frontend/src/apps/daccord/components/CreateRoomDialog.stories.tsx
+++ b/frontend/src/apps/daccord/components/CreateRoomDialog.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent } from 'storybook/test';
+import CreateRoomDialog from './CreateRoomDialog';
+
+const meta = {
+    title: 'Daccord/CreateRoomDialog',
+    component: CreateRoomDialog,
+    parameters: { layout: 'fullscreen' },
+    args: {
+        open: true,
+        creating: false,
+        errorMessage: null,
+        onClose: fn(),
+        onSubmit: fn(),
+    },
+    decorators: [
+        (Story) => (
+            <div
+                className="app-surface"
+                style={{
+                    position: 'relative',
+                    width: 720,
+                    height: 520,
+                    background:
+                        'linear-gradient(180deg, #f8fafc 0%, #ffffff 50%, #eff6ff 100%)',
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+} satisfies Meta<typeof CreateRoomDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {};
+
+export const Creating: Story = {
+    args: {
+        creating: true,
+    },
+};
+
+export const WithError: Story = {
+    args: {
+        errorMessage: 'Could not reach the server. Try again?',
+    },
+};
+
+export const SubmitsTitleAndScenario: Story = {
+    play: async ({ canvas, args }) => {
+        const title = await canvas.findByLabelText(/title/i);
+        await userEvent.type(title, 'Stealth HQ');
+
+        const scenario = await canvas.findByLabelText(/scenario/i);
+        await userEvent.type(scenario, 'Late-night planning session.');
+
+        const submit = canvas.getByRole('button', { name: /create room/i });
+        await userEvent.click(submit);
+
+        await expect(args.onSubmit).toHaveBeenCalledWith(
+            'Stealth HQ',
+            'Late-night planning session.',
+        );
+    },
+};
+
+export const CancelClosesDialog: Story = {
+    play: async ({ canvas, args }) => {
+        const cancel = canvas.getByRole('button', { name: /cancel/i });
+        await userEvent.click(cancel);
+        await expect(args.onClose).toHaveBeenCalled();
+    },
+};

--- a/frontend/src/apps/daccord/components/CreateRoomDialog.tsx
+++ b/frontend/src/apps/daccord/components/CreateRoomDialog.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import WindowFrame from '../../../components/desktop/WindowFrame';
+
+interface CreateRoomDialogProps {
+    open: boolean;
+    creating: boolean;
+    errorMessage?: string | null;
+    onClose: () => void;
+    onSubmit: (name: string, scenario: string) => void;
+}
+
+const SCENARIO_MAX = 2000;
+const SCENARIO_SOFT_WARN = 1800;
+
+export default function CreateRoomDialog({
+    open,
+    creating,
+    errorMessage,
+    onClose,
+    onSubmit,
+}: CreateRoomDialogProps) {
+    const [name, setName] = useState('');
+    const [scenario, setScenario] = useState('');
+    const nameId = useId();
+    const scenarioId = useId();
+    const frameId = useId();
+    const nameRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setScenario('');
+            return;
+        }
+        const t = window.setTimeout(() => nameRef.current?.focus(), 0);
+        return () => window.clearTimeout(t);
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && !creating) {
+                e.stopPropagation();
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [open, creating, onClose]);
+
+    if (!open) return null;
+
+    const trimmedName = name.trim();
+    const canSubmit = !creating && trimmedName.length > 0;
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!canSubmit) return;
+        onSubmit(trimmedName, scenario.trim());
+    };
+
+    const handleBackdrop = () => {
+        if (creating) return;
+        if (trimmedName || scenario.trim()) return;
+        onClose();
+    };
+
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                zIndex: 200,
+            }}
+        >
+            <button
+                type="button"
+                onClick={handleBackdrop}
+                aria-label="Close dialog"
+                tabIndex={-1}
+                className="absolute inset-0 cursor-default bg-black/50"
+            />
+            <div
+                role="dialog"
+                aria-label="Create a Room"
+                className="relative w-[440px] max-w-[92%] flex flex-col app-surface"
+            >
+                <WindowFrame
+                    id={frameId}
+                    title="Create a Room"
+                    icon="🏠"
+                    width={440}
+                    height={0}
+                    zIndex={200}
+                    focused
+                    onMinimize={onClose}
+                    onClose={onClose}
+                >
+                    <form
+                        onSubmit={handleSubmit}
+                        className="flex flex-col gap-3 p-4"
+                    >
+                        <div className="flex flex-col gap-1">
+                            <label
+                                htmlFor={nameId}
+                                className="text-[11px] font-bold"
+                            >
+                                Title
+                            </label>
+                            <input
+                                ref={nameRef}
+                                id={nameId}
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.currentTarget.value)}
+                                disabled={creating}
+                                maxLength={120}
+                                placeholder="e.g. Stealth Horticulture HQ"
+                                className="w-full"
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1">
+                            <div className="flex items-baseline justify-between">
+                                <label
+                                    htmlFor={scenarioId}
+                                    className="text-[11px] font-bold"
+                                >
+                                    Scenario{' '}
+                                    <span className="font-normal text-slate-500">
+                                        (optional)
+                                    </span>
+                                </label>
+                                {scenario.length > SCENARIO_SOFT_WARN && (
+                                    <span
+                                        className={`text-[10px] tabular-nums ${
+                                            scenario.length >= SCENARIO_MAX
+                                                ? 'text-red-600'
+                                                : 'text-amber-600'
+                                        }`}
+                                    >
+                                        {scenario.length}/{SCENARIO_MAX}
+                                    </span>
+                                )}
+                            </div>
+                            <textarea
+                                id={scenarioId}
+                                value={scenario}
+                                onChange={(e) =>
+                                    setScenario(e.currentTarget.value)
+                                }
+                                disabled={creating}
+                                rows={5}
+                                maxLength={SCENARIO_MAX}
+                                placeholder="Set the scene — e.g. 'Office of a stealth horticulture startup, late at night.'"
+                                className="w-full resize-none"
+                            />
+                        </div>
+
+                        {errorMessage && (
+                            <p
+                                role="alert"
+                                className="text-[11px] text-red-700 dark:text-red-300"
+                            >
+                                {errorMessage}
+                            </p>
+                        )}
+
+                        <div className="flex justify-end gap-2 pt-1">
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                disabled={creating}
+                            >
+                                Cancel
+                            </button>
+                            <button type="submit" disabled={!canSubmit}>
+                                {creating ? 'Creating…' : 'Create Room'}
+                            </button>
+                        </div>
+                    </form>
+                </WindowFrame>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/apps/daccord/components/DaccordSidebar.tsx
+++ b/frontend/src/apps/daccord/components/DaccordSidebar.tsx
@@ -20,6 +20,7 @@ interface DaccordSidebarProps {
     activeRoomId?: string;
     activeCategory: string;
     onSelectCategory: (id: string) => void;
+    onCreateRoom: () => void;
 }
 
 export default function DaccordSidebar({
@@ -28,6 +29,7 @@ export default function DaccordSidebar({
     activeRoomId,
     activeCategory,
     onSelectCategory,
+    onCreateRoom,
 }: DaccordSidebarProps) {
     const [yourRoomsOpen, setYourRoomsOpen] = useState(true);
 
@@ -75,10 +77,10 @@ export default function DaccordSidebar({
                             })}
                             <button
                                 type="button"
-                                disabled
-                                title="Create Hub"
-                                aria-label="Create Hub"
-                                className="relative mt-2 flex h-10 w-10 items-center justify-center self-start overflow-hidden rounded-full bg-gradient-to-br from-blue-400 via-blue-500 to-indigo-600 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.5),0_4px_10px_-2px_rgba(46,92,202,0.5)] ring-2 ring-white/60 opacity-90 cursor-not-allowed"
+                                onClick={onCreateRoom}
+                                title="Create Room"
+                                aria-label="Create Room"
+                                className="relative mt-2 flex h-10 w-10 items-center justify-center self-start overflow-hidden rounded-full bg-gradient-to-br from-blue-400 via-blue-500 to-indigo-600 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.5),0_4px_10px_-2px_rgba(46,92,202,0.5)] ring-2 ring-white/60 transition-transform hover:scale-110 hover:ring-white/80"
                             >
                                 <span
                                     className="text-lg leading-none"
@@ -104,11 +106,11 @@ export default function DaccordSidebar({
                                 <div className="mt-1 flex flex-col gap-0.5">
                                     {realRooms.length === 0 ? (
                                         <p className="px-3 py-2 text-[11px] text-slate-500 dark:text-slate-400">
-                                            No rooms yet. Create one in Discover
-                                            or the prompt below.
+                                            No rooms yet. Click + above to
+                                            create one.
                                         </p>
                                     ) : (
-                                        realRooms.slice(0, 6).map((r) => {
+                                        realRooms.map((r) => {
                                             const palette = paletteFor(r.id);
                                             const sub =
                                                 r.online != null
@@ -133,14 +135,6 @@ export default function DaccordSidebar({
                                                 />
                                             );
                                         })
-                                    )}
-                                    {realRooms.length > 6 && (
-                                        <button
-                                            type="button"
-                                            className="mt-1 px-3 py-1 text-left text-[11px] font-semibold text-blue-700 dark:text-blue-400 hover:underline"
-                                        >
-                                            See all rooms
-                                        </button>
                                     )}
                                 </div>
                             )}

--- a/frontend/src/apps/daccord/components/DiscoverFeed.tsx
+++ b/frontend/src/apps/daccord/components/DiscoverFeed.tsx
@@ -17,26 +17,16 @@ interface RealRoom {
 
 interface DiscoverFeedProps {
     realRooms: RealRoom[];
-    onCreateRoom: (name: string, scenario: string) => void;
-    creating: boolean;
     searchQuery: string;
     onSelectRealRoom: (id: string) => void;
-    inputName: string;
-    inputScenario: string;
-    onInputName: (v: string) => void;
-    onInputScenario: (v: string) => void;
+    onOpenCreate: () => void;
 }
 
 export default function DiscoverFeed({
     realRooms,
-    onCreateRoom,
-    creating,
     searchQuery,
     onSelectRealRoom,
-    inputName,
-    inputScenario,
-    onInputName,
-    onInputScenario,
+    onOpenCreate,
 }: DiscoverFeedProps) {
     const grassGradId = useId();
     const q = searchQuery.trim().toLowerCase();
@@ -294,47 +284,25 @@ export default function DiscoverFeed({
                 </>
             )}
 
-            {/* Create-room block (kept functional — uses real backend) */}
-            <SectionHeader title="Create a Room" />
-            <form
-                className="mb-10 flex flex-col gap-2 rounded-3xl bg-white/70 dark:bg-slate-800/70 p-4 shadow-[0_8px_24px_-8px_rgba(46,92,202,0.25)] ring-1 ring-white/60 dark:ring-slate-700 backdrop-blur-xl"
-                onSubmit={(e) => {
-                    e.preventDefault();
-                    if (creating) return;
-                    const name = inputName.trim();
-                    if (!name) return;
-                    onCreateRoom(name, inputScenario.trim());
-                }}
-            >
-                <input
-                    type="text"
-                    value={inputName}
-                    onChange={(e) => onInputName(e.currentTarget.value)}
-                    placeholder="Room name…"
-                    className="w-full rounded-full border border-slate-300/80 dark:border-slate-600 bg-white/90 dark:bg-slate-900 px-4 py-2 text-sm text-slate-800 dark:text-slate-100 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-                <textarea
-                    value={inputScenario}
-                    onChange={(e) => onInputScenario(e.currentTarget.value)}
-                    rows={2}
-                    maxLength={500}
-                    placeholder="Scenario (optional) — e.g. 'Office of a stealth horticulture startup.'"
-                    className="w-full rounded-2xl border border-slate-300/80 dark:border-slate-600 bg-white/90 dark:bg-slate-900 px-4 py-2 text-sm text-slate-800 dark:text-slate-100 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
+            {/* Create-room CTA — opens the modal */}
+            <SectionHeader title="Start Your Own Room" />
+            <div className="mb-10 flex flex-col items-start gap-3 rounded-3xl bg-white/70 dark:bg-slate-800/70 p-5 shadow-[0_8px_24px_-8px_rgba(46,92,202,0.25)] ring-1 ring-white/60 dark:ring-slate-700 backdrop-blur-xl">
+                <p className="text-[13px] text-slate-700 dark:text-slate-300">
+                    Spin up a fresh room with a title and an optional scenario
+                    to set the scene.
+                </p>
                 <button
-                    type="submit"
-                    disabled={creating || !inputName.trim()}
-                    className="relative self-start overflow-hidden rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-[0_6px_14px_-4px_rgba(46,92,202,0.5)] ring-1 ring-white/50 ring-inset hover:from-blue-600 hover:to-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
+                    type="button"
+                    onClick={onOpenCreate}
+                    className="relative overflow-hidden rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-[0_6px_14px_-4px_rgba(46,92,202,0.5)] ring-1 ring-white/50 ring-inset hover:from-blue-600 hover:to-indigo-700"
                 >
                     <span
                         aria-hidden
                         className="pointer-events-none absolute inset-x-0 top-0 h-1/2 rounded-t-full bg-gradient-to-b from-white/35 to-transparent"
                     />
-                    <span className="relative">
-                        {creating ? 'Creating…' : '+ Create Room'}
-                    </span>
+                    <span className="relative">+ Create Room</span>
                 </button>
-            </form>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- New `CreateRoomDialog` wrapped in the standard `WindowFrame` chrome (matches `ProviderModal`); collects title (required) + scenario (optional, 2000-char cap).
- Two entry points: the previously-disabled `+` button in the D'Accord sidebar, and a "+ Create Room" CTA replacing the inline form at the bottom of Discover.
- Sorts "Your Rooms" newest-first and removes the 6-row visible cap so freshly-created rooms appear immediately.
- Adds Storybook coverage: idle / creating / error / submit-flow / cancel-flow.

## Test plan
- [ ] Open D'Accord → click `+` in sidebar → modal opens with title focused.
- [ ] Submit empty title → button disabled.
- [ ] Fill title + scenario → Create → modal closes, room appears at top of "Your Rooms", auto-navigates into it.
- [ ] Repeat from the Discover CTA.
- [ ] ESC closes; backdrop closes only when both fields empty.
- [ ] Storybook variants render (links from `preview-stories`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Room creation now uses a dedicated modal dialog with enhanced validation and error messaging
  * "Create Room" button added to the sidebar for direct access

* **UI/UX Improvements**
  * Discover feed simplified to display a "+ Create Room" button
  * Room list now displays all available rooms instead of a limited preview
  * Dialog supports Escape key to close and validates input fields before submission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->