### PR TITLE
docs: scaffold agent-readable domain and process docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,3 +130,17 @@ DB init scripts in `docker-entrypoint-initdb.d/` are bind-mounted into the conta
 ### Deployment
 
 Deployed via [Kamal](https://kamal-deploy.org/). Config: `config/deploy.yml`, `config/deploy.frontend.yml`. Target: `game.timwillebrands.nl`. Accessories: DB + standalone Aspire dashboard. **Production does not use the AppHost** — Kamal builds `backend/Dockerfile` and `frontend/Dockerfile` directly. The backend image still emits OTLP via `OTEL_EXPORTER_OTLP_ENDPOINT` (set by Kamal to the dashboard accessory), which `AddServiceDefaults()` honors.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `TimWillebrands/window-into-proompting` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical names — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` and `docs/adr/` at repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,69 @@
+# Proompting
+
+The domain language of Proompting (aka Partytown): a Windows-XP-themed app where one human and several AI **Personas** hang out in **Rooms** and talk.
+
+## Language
+
+**Party**:
+A tenant boundary. Hosts a set of **Rooms** and a list of **Participants** (the **Personas** present in this Party). Each Party is a self-contained universe with its own cast, its own Rooms, and its own per-Persona **Memories**.
+_Avoid_: server, workspace, tenant, world, desktop.
+
+> Note: today the frontend always opens the default Party (id = `Guid.Empty`, exposed as `ROOT_PARTY_ID`). The API is fully multi-party; that surface is intentional, not dead code.
+
+**Room**:
+A named conversation thread inside a **Party** that a small cast of **Participants** talks in. Has its own message log, participant list, and optional **Scenario** text.
+_Avoid_: chat-group, chat-room, channel, thread.
+
+> Note: the backend code currently spells this `ChatGroup` (`ChatGroupGrain`, `ChatGroupEvent`, `chatGroupId` in API paths). That spelling is legacy — treat `Room` as the canonical name in all new code, comments, issues, and docs. Existing code can be renamed opportunistically.
+
+**Persona**:
+A character with a name, bio, system prompt, and behavioural dials (**Chattiness**, **Impulsivity**). Lives outside any Party — Personas are library entries that can join multiple Parties (eventually) and accumulate per-Party **Memories**. A Persona is a definition, not a membership.
+_Avoid_: character, agent, bot, NPC, user.
+
+**Participant**:
+A **Persona**'s membership in a **Party**. The link object that says "Persona X is in Party Y, driven by Z." Rooms draw their cast from the Party's Participants. Removing a Persona from a Party deletes the Participant; the Persona itself remains in the library. The Participant owns the **Driver** — the same Persona can be User-driven in one Party and LLM-driven in another.
+_Avoid_: member, attendee, party-member.
+
+**Driver**:
+The thing currently operating a **Participant**. Today, one of two kinds: `User` (a human types the messages) or `LLM` (the agent stack generates them). Driver lives on the Participant, not the Persona — so a Persona can have different Drivers in different Parties.
+_Avoid_: operator, pilot, controller, agent.
+
+> Note: today the backend expresses this as a `bool IsUser` flag on `PartyParticipant`. That flag is the current crude form of `Driver` — promote to a `DriverKind` enum (or equivalent) when a third kind appears.
+
+**Scenario**:
+Free-text in-fiction setup for a **Room**: where we are, what's going on, what the mood is. Visible to (and influences) every Persona in the Room. Optional — Rooms can have no Scenario.
+_Avoid_: prompt, setting, premise, context.
+
+### Persona behaviour dials
+
+**Chattiness** (0..1):
+A Persona's baseline urge to speak. Low = brooding, only chimes in when directly addressed or when something jumps out. High = wants in on every conversation.
+
+**Impulsivity** (0..1):
+How committed the Persona is to a reply once they've started forming one. Low = deliberative, easily interrupted by something new in the room. High = impulsive, barrels through their thought once committed.
+
+## Relationships
+
+- A **Party** contains zero or more **Rooms**.
+- A **Party** has zero or more **Participants**.
+- A **Participant** refers to exactly one **Persona**.
+- A **Persona** can be a **Participant** in zero or more **Parties** (one Participant per Party).
+- A **Room** draws its cast from its **Party**'s **Participants**.
+- A **Participant** has exactly one **Driver** (`User` or `LLM`).
+
+## Example dialogue
+
+> **Dev:** When the human sends a message in a **Room**, what's the sender on that message?
+> **Tim:** A **Participant** — specifically the one whose **Driver** is `User`. The human acts *through* a Persona; there's no separate "user message" path.
+>
+> **Dev:** So a **Persona** can be in multiple **Parties** with different Drivers in each?
+> **Tim:** Yes — same Persona, different Participants. The Driver lives on the Participant. Each Participant has its own per-Party Memories too, so the same Persona will "remember" different things depending on which Party you meet them in.
+>
+> **Dev:** If I delete a **Persona** from the library, what happens to a **Room** that had them as cast?
+> **Tim:** That's an ambiguity worth flagging — see below.
+
+## Flagged ambiguities
+
+- **"chat-group" / "ChatGroup"** was used throughout the backend to mean **Room** — resolved: **Room** is canonical; `ChatGroup` is a code-level legacy spelling that will be migrated opportunistically.
+- **`IsUser` flag** on `PartyParticipant` is the current crude form of **Driver** — resolved in vocabulary (`Driver` is canonical, `IsUser` is the legacy field), code rename deferred until a third `DriverKind` appears or auth lands.
+- **Persona deletion semantics** are not yet defined. If a Persona is deleted from the library, what happens to Participants referencing it (and to the messages they sent)? Soft-delete with tombstones? Hard delete with orphaned messages? Block deletion while participating? **Undecided.** Not blocking today — only set when this feature is built.

--- a/docs/adr/0001-stop-signal-race-emote-on-cancel.md
+++ b/docs/adr/0001-stop-signal-race-emote-on-cancel.md
@@ -1,0 +1,16 @@
+# Race-cancelled replies become in-character emotes, not errors
+
+When a new message arrives mid-generation, the in-flight Persona runs a **stop-signal race** (decide-phase → always cancel; generation past PNR → can't cancel; generation pre-PNR → score salience via LFM2 → cancel if `cancelScore > 0.5`). On cancel-pre-PNR, the half-formed reply is **discarded** and replaced with a freshly-generated, in-character abandonment line (`ChatMessage.Kind = "emote"`, rendered as an italic action), rather than dropping the message, surfacing a `[cancelled]` placeholder, or letting the stale reply complete.
+
+## Why this and not the obvious alternatives
+
+- **Why not silently drop?** The Room would lose a beat — the Persona was visibly typing/streaming, then nothing. Breaks the conversational rhythm and makes interruptions feel like bugs.
+- **Why not `[cancelled]` / error?** Breaks the fiction with system-y chrome. The whole product premise is "characters talking" — an OOC banner is a tonal break.
+- **Why not let it ride?** That's what pre-Race behavior was. Personas would steamroll over interjections, making fast-paced exchanges feel rude/dumb.
+
+## Consequences
+
+- Race-cancellation produces an **extra LLM call** (the emote generation) — paid per cancellation. Worth the cost because cancellations are the rare path and the emote is short.
+- The emote is generated against the *stale draft* + the *interrupting message*, so it can reference what the Persona was going to say. This is the point of keeping the draft around even after cancelling.
+- `Kind = "emote"` is now a permanent message taxonomy axis — anything that wants to filter "real speech vs in-character actions" must respect it.
+- Future work that introduces *other* Persona reactions (laughter, gestures, leaving the room) probably extends `Kind` rather than introducing parallel concepts.

--- a/docs/adr/0002-event-sourced-party-and-room-grains.md
+++ b/docs/adr/0002-event-sourced-party-and-room-grains.md
@@ -1,0 +1,23 @@
+# Event-source Party and Room, leave everything else plain
+
+`PartyGrain` and `ChatGroupGrain` (will be renamed `RoomGrain`) inherit `JournaledGrain<TState, TEvent>` and persist as a stream of events (`PartyEvent`, `ChatGroupEvent` subclasses). `PersonaGrain`, `LlmRouterGrain`, endpoint grains, and the root registry grains use plain state (or `IPersistentState<T>`). The event-sourcing choice is **scoped, not blanket**.
+
+## Why event-source Party + Room
+
+These two grains own the **conversational history** of the product — what was said, when, by whom, what generations were attempted, what the stop-signal race decided. That history is the *audit log of the product*, not just incidental state. Event-sourcing means:
+
+- The thought-log / papertrail / debug views are free — they're just projections of the journal.
+- Reprompts and message-deletions are events on top, not destructive overwrites — easy to add new history-rewrite operations without losing the prior shape.
+- Stop-signal race outcomes, skipped turns, and generation failures are first-class persisted history. Anyone (Persona, UI, future analytics) can replay them.
+
+## Why not event-source the rest
+
+- **Persona** is config — name, system prompt, dials. Edits are rare and don't form a history anyone reads back. Plain state wins on ceremony.
+- **LLM router / endpoint grains** are stateless or near-stateless (model lists, provider config). No history value.
+- **Root registry grains** are indices — they exist to enumerate, not to remember.
+
+## Consequences
+
+- Changing the event shape of `PartyEvent` / `ChatGroupEvent` is a migration, not a refactor. Adding events is safe; removing or renaming existing events requires upcast logic on the journal.
+- Snapshots may eventually be needed if the event journal of a long-running Party gets large. Not built yet — defer until it bites.
+- New "things that happened in a conversation" should default to a new event subclass, not a side table.

--- a/docs/adr/0003-custom-websocket-hub.md
+++ b/docs/adr/0003-custom-websocket-hub.md
@@ -1,0 +1,27 @@
+# Custom WebSocket hub now, SignalR later
+
+Realtime fan-out from the backend to the browser uses **raw `System.Net.WebSockets.WebSocket`** wrapped by `PartyRealtimeHub` (one session per Party, subscribed to Orleans streams), with a custom envelope `{ type, sequence, timestamp, data }`. SignalR — the .NET default — is **not** in use. Migration to SignalR is **planned**, not rejected.
+
+## Why raw WebSockets today
+
+- The hub's main job is to **bridge Orleans streams** (`IAsyncStream<PartyStreamEvent>`) into client WebSocket frames. Doing that with raw WS + a small envelope was a few hundred lines; doing it through SignalR's hub/client abstraction would have meant wiring Orleans-stream subscription into SignalR's connection lifecycle — more moving parts at a moment when the protocol shape was still being figured out.
+- Sequence numbers + a single message-merge path on the client (`realtime-store.ts`) were easier to design when both ends were ours, no client SDK conventions to fit.
+- Auth, fallback transports, and group/topic abstractions weren't needed yet — SignalR's wins didn't apply.
+
+## Why we'll move to SignalR
+
+- Reconnect, transport fallback (long-poll), and backpressure handling are nontrivial to do well; SignalR ships them.
+- Once auth lands, SignalR's per-connection auth context is much cleaner than rolling our own.
+- The custom envelope is bespoke knowledge every new contributor has to absorb. SignalR + typed hubs are familiar to most .NET devs.
+
+## When
+
+When one of the following bites: (a) reconnect/backpressure pain in production, (b) auth lands and starts duplicating SignalR's wheel, (c) a third client (mobile, CLI) needs to consume the stream and we don't want to re-implement the envelope.
+
+Until then this is **acknowledged tech debt**, not a long-term position. New features that go through the realtime path should be designed so they'd port cleanly to a SignalR hub method (no envelope-specific tricks).
+
+## Consequences
+
+- The whole realtime path is custom: envelope, session lifecycle, reconnect, message merging. Bugs there have no Stack Overflow answer.
+- The frontend `realtime-store.ts` is tightly coupled to the envelope shape. Any SignalR migration touches both sides.
+- Will be superseded by a future ADR once migration ships.

--- a/docs/adr/0004-postgres-age-for-persona-memories.md
+++ b/docs/adr/0004-postgres-age-for-persona-memories.md
@@ -1,0 +1,28 @@
+# Postgres + Apache AGE for Persona memories
+
+Persona memories will be stored as a **graph** in Postgres via the **Apache AGE** extension — the same database that already backs Orleans clustering and grain persistence. The graph is per-Party-per-Persona scope (a Persona has different memories in different Parties). Memories will store both event/relationship structure and embeddings for similarity lookup.
+
+The memory feature itself is **not yet built**. This ADR records the bet on AGE, not a completed implementation.
+
+## Why a graph
+
+A Persona's memories aren't flat rows — they're a mesh: "I think Vlad is impatient" links to "the time Vlad cut me off" links to the original Message and to the Room it happened in. Querying for "what does X think of Y" naturally walks this mesh.
+
+A graph DB lets us:
+
+- Store memories as nodes with typed edges (`thinks-about`, `triggered-by`, `said-in-room`).
+- Run cheap graph traversals when a Persona is generating ("walk from {this-Persona} via `thinks-about` toward {topic}, limit 3 hops").
+- Mix structural lookup (graph walk) with semantic lookup (embedding-nearest-neighbor on memory nodes) without a second store.
+
+## Why AGE and not Neo4j / a dedicated graph DB
+
+- Postgres is **already in the stack** for Orleans clustering and grain persistence. Adding AGE is a `CREATE EXTENSION`, not a new piece of infra to operate.
+- Memories will be queried in the same transactions as other state — staying in Postgres keeps that simple.
+- AGE speaks openCypher, which is the standard graph query language — not learning a one-DB-specific dialect.
+- If AGE turns out to be wrong (immature, slow, abandoned), we lose the *graph* shape, not the *database* — the memories can be migrated to a relational shape within the same Postgres without a cross-database move.
+
+## Consequences
+
+- AGE is less mature than Neo4j. Expect rough edges, especially in Orleans + Entity Framework toolchains.
+- The Postgres container image is a custom build (AGE-enabled). Anyone running the stack outside Aspire needs to know that.
+- This is a **bet, not a commitment**. If the memory feature ships and AGE bites, the structural escape hatch is relational tables in the same DB.

--- a/docs/adr/0005-windowing-state-in-url-search-params.md
+++ b/docs/adr/0005-windowing-state-in-url-search-params.md
@@ -1,0 +1,23 @@
+# Windowing state lives in URL search params, not a server-side session
+
+The XP desktop has exactly **one route** (`/`) and all window state — which apps are open, their positions, sizes, z-order, per-app props (which Room is open in a GroupChatWindow, which Persona is selected in PersonasApp, etc.) — is encoded into TanStack Router **search params**, validated by `desktopLayoutSchema`. There is no page-level routing; navigation between "screens" is opening/closing/focusing windows.
+
+## Why search params and not local state
+
+- **Shareable links.** A URL captures the entire desktop layout — including "this Room is open here, that Persona panel there." Send the URL, the recipient sees the same desktop.
+- **Refresh-safe.** Reloading the page restores the open windows exactly. No localStorage juggling.
+- **Browser back/forward** maps onto window-state history for free (paired with `useNavHistoryStore`).
+- **No server-side session** for layout state — the URL *is* the state. Keeps the backend pure: it knows about Parties / Rooms / Personas, not "which window is on top in someone's browser."
+
+## Why one route and not per-app routes
+
+- The XP metaphor is a desktop, not a webpage. Routes like `/personas` and `/rooms` would imply navigation away — wrong mental model.
+- Apps coexist; the user has multiple windows open at once. A route per app makes "Personas and a Room open side by side" awkward.
+- Window props (`{ partyId, chatGroupId }` for a Room window, etc.) belong with the window instance, not in a route shape.
+
+## Consequences
+
+- URLs are long. Worth it for shareability; ugly to look at.
+- Any new app on the desktop must register in `WINDOW_PRESETS` and round-trip through `desktopLayoutSchema`. Adding an app = adding a schema branch.
+- "Where am I" in the app is answered by `desktop-context`, not by the router — search-params parsing happens once, into Zustand, then the UI reads Zustand.
+- SSR / static deep-linking is harder: the route is always the same; only the search params differ. Cannot pre-render distinct pages.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Bootstrap the documentation surface the Matt Pocock engineering skills expect (`grill-with-docs`, `triage`, `to-issues`, etc.):

- CLAUDE.md: add `Agent skills` block pointing to docs/agents/*
- docs/agents/: issue tracker (GitHub gh CLI), triage labels (canonical names), and domain doc consumer rules
- CONTEXT.md: initial glossary — Party, Room, Persona, Participant, Driver, Scenario, Chattiness, Impulsivity, with relationships and example dialogue
- docs/adr/0001-0005: stop-signal race emote-on-cancel, event- sourced Party/Room grains, custom WebSocket hub (planned SignalR migration), Postgres+AGE memory bet, URL-search-param windowing state

Renames 'ChatGroup' to 'Room' in vocabulary; code rename deferred. Memory + decision-pipeline terms deferred until those shapes stabilize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded domain language specification and terminology guide.
  * Added architectural decision records covering system design patterns including message handling, data persistence, real-time communication, state management, and memory storage.
  * Added comprehensive guidance documentation for consuming repository reference materials and GitHub workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimWillebrands/window-into-proompting/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->