### PR TITLE
docs(memory): design v2 — Reality + Stance/Recollection model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,48 @@ A Persona's baseline urge to speak. Low = brooding, only chimes in when directly
 **Impulsivity** (0..1):
 How committed the Persona is to a reply once they've started forming one. Low = deliberative, easily interrupted by something new in the room. High = impulsive, barrels through their thought once committed.
 
+### Memory
+
+A Persona's memory is the set of edges from a **Participant** (or the underlying **Persona**) to entities in **Reality**. The edges carry the personal view — the entities themselves do not.
+
+**Recollection**:
+A **Participant**'s edge to an **Event** in **Reality**. Carries a short, second-person snippet ("you saw Vlad cut Hana off"). One Event can have many Recollections — one per Participant who remembers it, each with their own spin. Snippet-only for now; if a recollection *changes how the Persona feels* about someone or something, that lives as a separate **Stance**.
+_Avoid_: episode, snippet, memory-line, recall.
+
+**Stance**:
+A Persona's feeling/opinion/orientation toward a target — another **Participant** ("Vlad is impatient"), a **Concept** ("Lisp is elegant"), or themselves. Carries valence and free-text reasoning. First-class entity — *not* prose buried in a bio.
+_Avoid_: opinion, attitude, feeling, take, belief.
+
+**Intrinsic Stance**:
+A **Stance** attached at the **Persona** library level — part of who the Persona *is*. Travels into every **Party** the Persona joins. Authored in persona-management UI, or **promoted** from an **Acquired Stance**.
+_Avoid_: baseline-stance, default-stance, hardcoded-stance.
+
+**Acquired Stance**:
+A **Stance** formed during play, attached to a **Participant** — local to one **Party**. Stays there unless **promoted**.
+_Avoid_: learned-stance, runtime-stance, in-party-stance.
+
+**Promotion**:
+The act of lifting an **Acquired Stance** to an **Intrinsic Stance** — "this is now part of who Denise is, not just Denise-in-this-Party." Author-driven, not automatic. Concretely: a new edge at **Persona** scope is written, capturing the *current projection* of the Acquired stance at the moment of promotion. The original Acquired observations stay where they happened.
+_Avoid_: ascend, lift, propagate, graduate.
+
+> Note: **Stance** is append-only — each capture writes a new edge with a timestamp, valence, and reasoning. The "current" stance is just the latest edge wins (per (Persona, Target)), unioned across Participant-scope and Persona-scope. No materialised projection table.
+
+**Consolidation**:
+A background pass that walks a **Participant**'s recent **Recollections** involving a target (a **Concept** or another **Participant**) and emits new **Stance** edges where a coherent belief has crystallised. Author-triggered (button or schedule) — *not* coupled to generation. Loose analogue to memory consolidation in sleep: episodes accumulate, beliefs crystallise later.
+_Avoid_: digest, summarisation, reflection, dream.
+
+### Reality
+
+The shared, objective layer that **Personas** and **Participants** form **Stances** toward. Entities in Reality live independently of any Persona — multiple Personas can attach different Stances (and other edges) to the same entity. Think of Reality as the world; Memory is each Persona's view of that world.
+
+**Concept**:
+A "thing in reality" — abstract or concrete — that a Persona can have a **Stance** toward. "Lisp", "Software", "kindness". Flat for now (no hierarchy — see flagged ambiguities). Auto-created on first reference, mergeable in UI.
+_Avoid_: topic, tag, thing, subject.
+
+**Event**:
+A crystallized moment in **Reality** that **Participants** may **Recollect**. An Event often *points to* a **Message** (or a span of Messages) when it happened in a Room — the Message holds the raw content, the Event is the anchor multiple **Recollections** hang off. Events can also represent backstory or non-Message reality (Scenario change, a Persona joining a Room) without a Message anchor. Events carry **objective** edges to the **Concepts** and **Participants** they are *about* (used by graph-walk recall) — these tags belong to the Event, not to any single Recollection of it. Subjective spin lives only on the Recollection edge.
+_Avoid_: episode, fact, occurrence, snapshot.
+
 ## Relationships
 
 - A **Party** contains zero or more **Rooms**.

--- a/docs/adr/0006-pure-age-for-memory.md
+++ b/docs/adr/0006-pure-age-for-memory.md
@@ -1,0 +1,42 @@
+# Pure AGE for memory data, EF only as a connection holder
+
+The memory subsystem (**Concept**, **Event**, **Stance**, **Recollection**) stores its canonical state as **Apache AGE** vertices and edges. There are **no EF Core entities** for memory and **no EF migrations** on the memory schema. The existing `AppDbContext` is kept solely to host `Database.SqlQueryRaw<T>` — Cypher is the query language, EF is just the connection holder and DTO mapper. The memory subsystem accesses the database **directly** from services, not via Orleans grains.
+
+This builds on the bet in [ADR 0004](0004-postgres-age-for-persona-memories.md).
+
+## Why pure AGE (not a hybrid EF + AGE store)
+
+ADR 0004 bets on AGE because the data is a mesh (Persona → Concept → Event → Recollection → …) and graph traversals are the natural recall query. A hybrid store — EF rows as the source of truth with AGE as a derived graph view — is a half-bet:
+
+- Two stores must stay in sync. The sync layer becomes the most-mutated, least-typed surface in the subsystem.
+- Recall walks would run on the derived store; writes would run on the canonical one. Writes that "feel atomic" no longer are.
+- We'd pay AGE complexity *and* EF migration complexity at once.
+
+Pure AGE keeps a single source of truth. If the AGE bet fails, ADR 0004's escape hatch (relational tables in the same Postgres) still applies — the migration is local, not cross-database.
+
+## Why not grain-mediated
+
+Recall is a graph walk that spans every Participant and Event in a Party, not a single grain's state. Wrapping that in an Orleans grain means either:
+
+- Each grain holds a slice of the graph (then walks need cross-grain orchestration, which is fighting the actor model), or
+- One grain holds the whole graph (then it's a singleton in front of the database — pure ceremony).
+
+Memory writes are also low-throughput and uncontended. Orleans' concurrency model doesn't earn its place here. The PoC's instinct (controller → service → DB) was right; keep it.
+
+## Why keep `AppDbContext` at all
+
+Reasons it stays:
+
+- Connection pooling and `ServiceProvider` integration come for free.
+- `Database.SqlQueryRaw<T>` maps result rows into plain C# records — cheaper than reaching for Npgsql + Dapper for the same job.
+- Other features may eventually want EF for non-memory data; the context already exists.
+
+There are **no `DbSet<>`s for memory entities**. The context is an execution surface, not a model.
+
+## Consequences
+
+- **Schema lives in Cypher DDL**, not EF migrations. Manage it in `docker-entrypoint-initdb.d/` (or an equivalent versioned init script). EF's `dotnet ef migrations` will not see memory entities.
+- **Ad-hoc inspection is harder.** No LINQ; admin queries are Cypher. Worth a small helper layer in the backend (`IMemoryRepository` with a few common projections) so callers don't write raw Cypher everywhere.
+- **`agtype` casts in every query.** AGE returns its own graph type by default; every `RETURN` needs explicit casts to `text` / `int` / `uuid` for `SqlQueryRaw<T>` to map cleanly. Boilerplate is real but contained.
+- **Orleans serialization stays out of the memory path.** Memory DTOs cross the service boundary as plain records, never as grain method returns. Avoids the Orleans codec footguns flagged in `CLAUDE.md`.
+- **Reversal cost is bounded.** If AGE has to go, the rewrite is "translate Cypher to recursive CTEs" — schema and access pattern stay close to today's shape.

--- a/docs/adr/0007-append-only-stance-edges.md
+++ b/docs/adr/0007-append-only-stance-edges.md
@@ -1,0 +1,25 @@
+# Stance is append-only; current belief is computed, not stored
+
+Every **Stance** capture writes a *new* edge in AGE between a **Persona** (Intrinsic) or **Participant** (Acquired) and a target (**Concept**, **Participant**, or self), carrying `(valence, reasoning, timestamp)`. No edge is ever mutated. The "current Stance" for a `(Persona, Target)` pair is just **the latest edge wins**, computed at read time over the union of Persona-scope and Participant-scope edges. There is **no materialised current-Stance table**.
+
+## Why append-only
+
+A Persona's beliefs evolve over a Party's lifetime — Denise warms up to Lisp, Vlad's reputation slides after one too many interruptions. That evolution is the *point* of the memory feature. Mutable upsert loses it.
+
+- Matches the event-sourced precedent from [ADR 0002](0002-event-sourced-party-and-room-grains.md): conversational history is journalled; beliefs are part of the same world.
+- **Promotion** (Acquired → Intrinsic) is just "write a new edge at Persona scope with today's timestamp and the current projection." No diff-tracking, no record mutation.
+- **Time-travel queries are free**: "what did Denise believe about Lisp on 2026-03-01?" = `WHERE ts < '2026-03-01' ORDER BY ts DESC LIMIT 1`.
+- **Consolidation** can rerun safely. Idempotency falls out — repeat runs append duplicate edges, latest still wins, no corruption.
+
+## Why no materialised current-Stance table
+
+- Read pattern is *cold and small*: a few Stances per Persona, read at generation time. Computing the projection on read is one indexed lookup per `(Persona, Target)` pair.
+- A materialised table would have to stay consistent with every Stance write — a separate write path, a separate failure mode, and a backfill on every schema change.
+- If projection latency ever bites at scale, the materialised table is straightforward to add behind the same `IMemoryRepository` interface. Defer until it bites.
+
+## Consequences
+
+- **Stance growth is unbounded.** Beliefs are coarse and infrequent, so this is likely a non-issue for years. If hot in practice, add archival or per-`(Persona, Target)` retention.
+- **Latest-wins is recency-biased.** A noisy or hallucinated capture overrides everything earlier. Mitigation lives in the **Consolidation** flow — diff-review UX: the curator approves a proposed Stance before it's written. Captures themselves don't write Stances (see the **Recollection-only at capture** decision in `CONTEXT.md`).
+- **No Stance ever truly disappears.** "Deletion" is a tombstone edge or a new edge with neutral valence — the prior history stays. Acceptable; matches event-sourced norms.
+- **Union queries cross scope.** Every read merges Persona-scope (Intrinsic) and Participant-scope (Acquired) edges. The graph walk in recall does this naturally; ad-hoc queries need to remember it.


### PR DESCRIPTION
Captures the design from a grill-with-docs session re-planning the
persona memory feature after the manual-trigger PoC. The PoC code itself
lives on a separate branch and will be thrown.

CONTEXT.md additions:
- Memory section: Recollection, Stance, Intrinsic/Acquired Stance,
  Promotion, Consolidation
- Reality section: Concept, Event — the objective layer that Stances
  and Recollections form edges into

ADR 0006: Pure AGE for the memory subsystem. EF Core is kept only as
a connection holder for Database.SqlQueryRaw<T>; no DbSets, no EF
migrations on the memory schema. Memory access is direct from
services, not grain-mediated.

ADR 0007: Stance edges are append-only and timestamped. The "current"
belief is computed at read time (latest edge wins, union of Persona-
and Participant-scope). No materialised projection table. Promotion
is just a new edge at Persona scope.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded domain language with Memory and Reality concepts including Recollection (participant memory of events) and Stance (persona opinions toward entities).
  * Documented memory subsystem architecture using append-only stance edges stored in the graph database.
  * Defined Consolidation process for converting memory patterns into new stance edges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimWillebrands/window-into-proompting/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->