### PR TITLE
Extract RaceTrigger from PersonaGrain

### DIFF
--- a/backend-test/PersonaGrainFeedbackTest.cs
+++ b/backend-test/PersonaGrainFeedbackTest.cs
@@ -8,6 +8,7 @@ using Orleans.TestKit;
 using PartyTown.Grains;
 using PartyTown.Grains.Generation;
 using PartyTown.Model;
+using PartyTown.Services.ResponsePipeline;
 using PartyTown.Services.Streaming;
 
 namespace BackendTest;
@@ -110,6 +111,7 @@ public class PersonaGrainFeedbackTest : TestKitBase
         // TestKit's auto-wired logger factory can produce loggers with null internals;
         // NullLoggerFactory is safe.
         Silo.AddService<ILoggerFactory>(NullLoggerFactory.Instance);
+        Silo.AddService(new RaceTrigger(Silo.GrainFactory, NullLoggerFactory.Instance));
 
         // Router probe: routes all job complexities to the same fake endpoint
         endpoint.RegisterOn(Silo);
@@ -249,6 +251,7 @@ public class PersonaGrainFeedbackTest : TestKitBase
         personaRoot.Setup(g => g.GetAll()).ReturnsAsync(new Persona[] { new() { Id = _personaId, Name = PersonaName, SystemPrompt = "..." } });
 
         Silo.AddService<ILoggerFactory>(NullLoggerFactory.Instance);
+        Silo.AddService(new RaceTrigger(Silo.GrainFactory, NullLoggerFactory.Instance));
 
         var router = Silo.AddProbe<ILlmRouterGrain>(0L);
         router.Setup(r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()))
@@ -318,6 +321,7 @@ public class PersonaGrainFeedbackTest : TestKitBase
         personaRoot.Setup(g => g.GetAll()).ReturnsAsync(new Persona[] { new() { Id = _personaId, Name = PersonaName, SystemPrompt = "..." } });
 
         Silo.AddService<ILoggerFactory>(NullLoggerFactory.Instance);
+        Silo.AddService(new RaceTrigger(Silo.GrainFactory, NullLoggerFactory.Instance));
 
         var router = Silo.AddProbe<ILlmRouterGrain>(0L);
         router.Setup(r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()))
@@ -431,6 +435,7 @@ public class PersonaGrainFeedbackTest : TestKitBase
         personaRoot.Setup(g => g.GetAll()).ReturnsAsync(new Persona[] { new() { Id = _personaId, Name = PersonaName, SystemPrompt = "..." } });
 
         Silo.AddService<ILoggerFactory>(NullLoggerFactory.Instance);
+        Silo.AddService(new RaceTrigger(Silo.GrainFactory, NullLoggerFactory.Instance));
 
         var router = Silo.AddProbe<ILlmRouterGrain>(0L);
         router.Setup(r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()))

--- a/backend-test/RaceTriggerTest.cs
+++ b/backend-test/RaceTriggerTest.cs
@@ -1,0 +1,300 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using PartyTown.Grains;
+using PartyTown.Grains.Generation;
+using PartyTown.Model;
+using PartyTown.Services.ResponsePipeline;
+
+namespace BackendTest;
+
+/// <summary>
+/// Tests for <see cref="RaceTrigger"/> — the stop-signal race extracted from
+/// <c>PersonaGrain</c>. Covers the five race outcomes from the issue:
+///
+///   • cancel-decision   (Decision phase → always cancel)
+///   • past-pnr          (Speaking phase, tokens ≥ PnrTokens → repair hint, no cancel)
+///   • cancel-generation (Speaking pre-PNR, cancelScore &gt; 0.5 → cancel + race-cancelled flag)
+///   • continue          (Speaking pre-PNR, cancelScore ≤ 0.5 → repair hint, no cancel)
+///   • let-it-ride       (salience throws → behaves like SalienceScore.LetItRide → no cancel)
+///
+/// Strategy: real <see cref="InFlightStore"/>, mock <see cref="IChatGroupGrain"/> probe
+/// for participants + papertrail capture, mock <see cref="IGrainFactory"/> + mock
+/// <see cref="ILlmRouterGrain"/> for the salience-service path (only exercised by the
+/// pre-PNR outcomes).
+/// </summary>
+public class RaceTriggerTest
+{
+    private const string PersonaName = "Vlad";
+    private static readonly Guid PersonaId = Guid.NewGuid();
+
+    // PNR threshold lives on RaceTrigger as a private const (80 tokens, ~4 chars/token).
+    // Generate enough chars to push past it deterministically (90 tokens worth = 360 chars).
+    private const string PastPnrText =
+        "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" +
+        "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" +
+        "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" +
+        "012345678901234567890123456789012345678901234567890123456789";
+
+    private static Persona MakePersona(double impulsivity = 0.5) => new()
+    {
+        Id = PersonaId,
+        Name = PersonaName,
+        SystemPrompt = "You are Vlad.",
+        Bio = "Reluctant philosopher",
+        Chattiness = 0.5,
+        Impulsivity = impulsivity,
+    };
+
+    private static ChatMessage NewTrigger(Guid senderId, string content = "hey wait") => new()
+    {
+        MessageId = 99,
+        SenderId = senderId,
+        SenderType = "user",
+        Content = content,
+    };
+
+    /// <summary>
+    /// Build a mocked <see cref="IChatGroupGrain"/> that:
+    ///   • returns a single non-self participant from GetParticipantsAsync (for sender-name resolution)
+    ///   • records every RecordRaceEvaluationAsync call into the provided outcomes list
+    /// </summary>
+    private static Mock<IChatGroupGrain> MakeChatGroup(
+        Guid otherParticipantId,
+        string otherParticipantName,
+        List<(string outcome, double? salience, double? cancelScore)> outcomes)
+    {
+        var mock = new Mock<IChatGroupGrain>();
+        mock.Setup(g => g.GetParticipantsAsync())
+            .ReturnsAsync(new List<PartyParticipant>
+            {
+                new() { Id = PersonaId, Name = PersonaName, IsUser = false },
+                new() { Id = otherParticipantId, Name = otherParticipantName, IsUser = true },
+            });
+        mock.Setup(g => g.RecordRaceEvaluationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<string>(), It.IsAny<double?>(), It.IsAny<double?>()))
+            .Returns<Guid, string, int, string, double?, double?>(
+                (_, _, _, outcome, sal, cs) =>
+                {
+                    outcomes.Add((outcome, sal, cs));
+                    return Task.CompletedTask;
+                });
+        return mock;
+    }
+
+    /// <summary>
+    /// Build a fake grain factory whose <c>GetGrain&lt;ILlmRouterGrain&gt;(0, null)</c> returns
+    /// the supplied router mock. Other GetGrain overloads/types throw — only the salience
+    /// path needs the router, and we want surprises to be loud.
+    /// </summary>
+    private static Mock<IGrainFactory> MakeGrainFactory(Mock<ILlmRouterGrain> router)
+    {
+        var factory = new Mock<IGrainFactory>();
+        factory.Setup(f => f.GetGrain<ILlmRouterGrain>(0L, null)).Returns(router.Object);
+        return factory;
+    }
+
+    /// <summary>Router that responds to RouteAsync with an endpoint streaming the given JSON salience response.</summary>
+    private static Mock<ILlmRouterGrain> MakeRouterWithSalience(string salienceJson)
+    {
+        var endpoint = new Mock<ILlmEndpointGrain>();
+        endpoint.Setup(e => e.GenerateAsync(It.IsAny<LlmGenerationJob>(), It.IsAny<CancellationToken>()))
+            .Returns<LlmGenerationJob, CancellationToken>((_, ct) => SingleChunk(salienceJson, ct));
+        endpoint.Setup(e => e.GetAttributionAsync())
+            .ReturnsAsync(new ChatMessageMetadata { Provider = "test", ModelName = "lfm2-test" });
+
+        var router = new Mock<ILlmRouterGrain>();
+        router.Setup(r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(endpoint.Object);
+        return router;
+    }
+
+    private static async IAsyncEnumerable<LlmGenerationEvent> SingleChunk(
+        string data,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        await Task.Yield();
+        yield return new LlmGenerationEvent(LlmGenerationEvent.ContentChunk, data);
+    }
+
+    private static RaceTrigger MakeTrigger(Mock<IGrainFactory> factory) =>
+        new(factory.Object, NullLoggerFactory.Instance);
+
+    // ── outcomes ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_DecisionPhase_AlwaysCancels()
+    {
+        // Arrange: in-flight gen still in Decision phase. No salience call expected —
+        // the race shortcircuits to cancel.
+        var store = new InFlightStore();
+        var chatGroupId = Guid.NewGuid();
+        var cts = new CancellationTokenSource();
+        var gen = store.Register(chatGroupId, messageId: 7, cts);
+
+        var senderId = Guid.NewGuid();
+        var outcomes = new List<(string, double?, double?)>();
+        var chatGroup = MakeChatGroup(senderId, "Mira", outcomes);
+        var router = MakeRouterWithSalience("""{"salience":0.0,"kind":"irrelevant"}""");
+        var factory = MakeGrainFactory(router);
+        var trigger = MakeTrigger(factory);
+
+        // Act
+        await trigger.EvaluateAsync(
+            MakePersona(), chatGroupId, NewTrigger(senderId), chatGroup.Object, store,
+            CancellationToken.None);
+
+        // Assert: gen cancelled, race-cancelled flag set, outcome recorded
+        var snap = gen.Snapshot();
+        Assert.True(snap.RaceCancelled);
+        Assert.True(cts.IsCancellationRequested);
+        Assert.Single(outcomes);
+        Assert.Equal("cancel-decision", outcomes[0].Item1);
+        // Salience never consulted on decision-phase cancel.
+        router.Verify(
+            r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SpeakingPastPnr_SetsRepairHintAndSkipsCancel()
+    {
+        // Arrange: in-flight gen in Speaking phase with enough chars to push past PNR (80 tokens, ~320 chars).
+        var store = new InFlightStore();
+        var chatGroupId = Guid.NewGuid();
+        var cts = new CancellationTokenSource();
+        var gen = store.Register(chatGroupId, messageId: 7, cts);
+        gen.MarkGenerationStarted("gut", "would say");
+        gen.AppendChunk(PastPnrText); // 360+ chars → 90+ tokens → past PnrTokens=80
+
+        var senderId = Guid.NewGuid();
+        var outcomes = new List<(string, double?, double?)>();
+        var chatGroup = MakeChatGroup(senderId, "Mira", outcomes);
+        var router = MakeRouterWithSalience("""{"salience":1.0,"kind":"contradict"}""");
+        var factory = MakeGrainFactory(router);
+        var trigger = MakeTrigger(factory);
+
+        // Act
+        await trigger.EvaluateAsync(
+            MakePersona(), chatGroupId, NewTrigger(senderId, "forget that"), chatGroup.Object, store,
+            CancellationToken.None);
+
+        // Assert: no cancellation, repair hint stashed for next decision pass, salience never burned
+        Assert.False(gen.Snapshot().RaceCancelled);
+        Assert.False(cts.IsCancellationRequested);
+        var hint = store.ConsumeRepairHint(chatGroupId);
+        Assert.True(hint.HasValue);
+        Assert.Equal(99, hint!.Value.MissedMessageId);
+        Assert.Single(outcomes);
+        Assert.Equal("past-pnr", outcomes[0].Item1);
+        router.Verify(
+            r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SpeakingPrePnr_HighSalience_CancelsGeneration()
+    {
+        // Arrange: Speaking phase, no tokens yet (commitmentProgress=0), impulsivity=0.
+        // cancelScore = salience * (1 - 0) * (1 - 0) = salience. High salience → cancel.
+        var store = new InFlightStore();
+        var chatGroupId = Guid.NewGuid();
+        var cts = new CancellationTokenSource();
+        var gen = store.Register(chatGroupId, messageId: 7, cts);
+        gen.MarkGenerationStarted("planning to defend it", "I think it's actually good");
+
+        var senderId = Guid.NewGuid();
+        var outcomes = new List<(string, double?, double?)>();
+        var chatGroup = MakeChatGroup(senderId, "Mira", outcomes);
+        var router = MakeRouterWithSalience("""{"salience":0.95,"kind":"contradict"}""");
+        var factory = MakeGrainFactory(router);
+        var trigger = MakeTrigger(factory);
+
+        // Act
+        await trigger.EvaluateAsync(
+            MakePersona(impulsivity: 0.0), chatGroupId, NewTrigger(senderId, "no it's broken"),
+            chatGroup.Object, store, CancellationToken.None);
+
+        // Assert: race elected to cancel; race-cancelled flag set so the catch in PersonaGrain
+        // routes to the emote path instead of marking failed.
+        var snap = gen.Snapshot();
+        Assert.True(snap.RaceCancelled);
+        Assert.True(cts.IsCancellationRequested);
+        Assert.Single(outcomes);
+        Assert.Equal("cancel-generation", outcomes[0].Item1);
+        Assert.NotNull(outcomes[0].Item2);
+        Assert.True(outcomes[0].Item3 > 0.5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SpeakingPrePnr_LowSalience_ContinuesAndSetsRepairHint()
+    {
+        // Arrange: low salience → cancelScore stays under threshold → continue branch.
+        var store = new InFlightStore();
+        var chatGroupId = Guid.NewGuid();
+        var cts = new CancellationTokenSource();
+        var gen = store.Register(chatGroupId, messageId: 7, cts);
+        gen.MarkGenerationStarted("gut", "would say");
+
+        var senderId = Guid.NewGuid();
+        var outcomes = new List<(string, double?, double?)>();
+        var chatGroup = MakeChatGroup(senderId, "Mira", outcomes);
+        var router = MakeRouterWithSalience("""{"salience":0.1,"kind":"tangent"}""");
+        var factory = MakeGrainFactory(router);
+        var trigger = MakeTrigger(factory);
+
+        // Act
+        await trigger.EvaluateAsync(
+            MakePersona(impulsivity: 0.5), chatGroupId, NewTrigger(senderId, "btw lunch"),
+            chatGroup.Object, store, CancellationToken.None);
+
+        // Assert: no cancel, repair hint set for next decision pass, outcome "continue"
+        Assert.False(gen.Snapshot().RaceCancelled);
+        Assert.False(cts.IsCancellationRequested);
+        var hint = store.ConsumeRepairHint(chatGroupId);
+        Assert.True(hint.HasValue);
+        Assert.Equal(99, hint!.Value.MissedMessageId);
+        Assert.Single(outcomes);
+        Assert.Equal("continue", outcomes[0].Item1);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SpeakingPrePnr_SalienceThrows_LetsItRide()
+    {
+        // Arrange: salience routing throws → service returns SalienceScore.LetItRide internally,
+        // cancelScore math collapses to 0, never crosses the threshold. The in-flight gen
+        // survives untouched — this is the conservative fallback that preserves current
+        // behavior when the cheap salience model is unavailable.
+        var store = new InFlightStore();
+        var chatGroupId = Guid.NewGuid();
+        var cts = new CancellationTokenSource();
+        var gen = store.Register(chatGroupId, messageId: 7, cts);
+        gen.MarkGenerationStarted("gut", "would say");
+
+        var senderId = Guid.NewGuid();
+        var outcomes = new List<(string, double?, double?)>();
+        var chatGroup = MakeChatGroup(senderId, "Mira", outcomes);
+
+        var router = new Mock<ILlmRouterGrain>();
+        router.Setup(r => r.RouteAsync(It.IsAny<JobComplexity>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("no CharacterThoughts provider"));
+        var factory = MakeGrainFactory(router);
+        var trigger = MakeTrigger(factory);
+
+        // Act
+        await trigger.EvaluateAsync(
+            MakePersona(impulsivity: 0.0), chatGroupId, NewTrigger(senderId),
+            chatGroup.Object, store, CancellationToken.None);
+
+        // Assert: in-flight survives. RaceCancelled stays false, CTS not tripped.
+        // Behavior matches SalienceScore.LetItRide (cancelScore=0 → continue branch).
+        Assert.False(gen.Snapshot().RaceCancelled);
+        Assert.False(cts.IsCancellationRequested);
+        // Outcome papertrail records "continue" with salience=0 — the LetItRide value.
+        Assert.Single(outcomes);
+        Assert.Equal("continue", outcomes[0].Item1);
+        Assert.Equal(0.0, outcomes[0].Item2);
+    }
+}

--- a/backend/Grains/PersonaGrain.cs
+++ b/backend/Grains/PersonaGrain.cs
@@ -21,17 +21,11 @@ public sealed class PersonaGrain(
     IPersistentState<Persona> state,
     ILoggerFactory loggerFactory,
     IMemoryRepository memoryRepository,
+    RaceTrigger raceTrigger,
     ILogger<PersonaGrain> logger)
     : Grain, IPersonaGrain
 {
     private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
-
-    // Stop-signal race tunables. PNR is the absolute generated-token count past which an
-    // in-flight generation cannot be cancelled (only repaired on the next turn). Cancel
-    // threshold is the cancelScore above which the race elects to cancel.
-    // See plans/well-i-controll-henk-eventual-stearns.md for derivation.
-    private const int PnrTokens = 80;
-    private const double CancelThreshold = 0.5;
 
     private readonly InFlightStore _store = new();
 
@@ -130,7 +124,7 @@ public sealed class PersonaGrain(
         // group, decide cancel-vs-continue against the new message. Runs BEFORE the
         // pre-gate so the in-flight work is interrupted even when this persona would
         // ultimately skip the new message itself (correctness > saved compute).
-        await RunStopSignalRaceAsync(chatGroupId, triggeringMessage, persona, chatGroupGrain, ct);
+        await raceTrigger.EvaluateAsync(persona, chatGroupId, triggeringMessage, chatGroupGrain, _store, ct);
 
         // Pre-gate: snapshot history before reserving a slot so an obvious-skip persona
         // leaves no trace in the chat (no message slot → no thought-log entry → no LLM call).
@@ -521,185 +515,6 @@ public sealed class PersonaGrain(
         }
 
         return result!;
-    }
-
-    /// <summary>
-    /// Stop-signal race: when a new message arrives, walk this persona's in-flight
-    /// generations in this chat group and decide cancel-vs-continue per generation.
-    ///   • Decision phase → always cancel (cheap; no public artifact yet).
-    ///   • Speaking phase past PNR → cannot cancel; record a repair hint for next turn.
-    ///   • Speaking phase pre-PNR → score salience via LFM2; cancel if cancelScore > 0.5,
-    ///     otherwise record a repair hint.
-    /// Salience or routing failures default to "let it ride" (no cancel, no repair) —
-    /// preserves current behavior rather than introducing a new failure surface.
-    /// </summary>
-    private async Task RunStopSignalRaceAsync(
-        Guid chatGroupId,
-        ChatMessage triggeringMessage,
-        Persona persona,
-        IChatGroupGrain chatGroupGrain,
-        CancellationToken ct)
-    {
-        var snapshot = _store.SnapshotForChatGroup(chatGroupId);
-
-        if (snapshot.Count == 0)
-            return;
-
-        string? senderName = null;
-        async Task<string> ResolveSenderNameAsync()
-        {
-            if (senderName is not null) return senderName;
-            try
-            {
-                var participants = await chatGroupGrain.GetParticipantsAsync();
-                senderName = participants.FirstOrDefault(p => p.Id == triggeringMessage.SenderId)?.Name
-                             ?? triggeringMessage.SenderId.ToString();
-            }
-            catch
-            {
-                senderName = triggeringMessage.SenderId.ToString();
-            }
-            return senderName;
-        }
-
-        foreach (var (inFlightMessageId, gen) in snapshot)
-        {
-            using var raceSpan = Tracing.Persona.StartActivity("persona.race", ActivityKind.Internal);
-            raceSpan?.SetTag("persona.id", this.GetPrimaryKey());
-            raceSpan?.SetTag("persona.name", persona.Name);
-            raceSpan?.SetTag("in_flight.message_id", inFlightMessageId);
-            raceSpan?.SetTag("triggered_by.message_id", triggeringMessage.MessageId);
-
-            var snap = gen.Snapshot();
-            raceSpan?.SetTag("in_flight.phase", snap.Phase.ToString());
-            raceSpan?.SetTag("in_flight.tokens", snap.GeneratedTokens);
-
-            if (snap.Phase == InFlightPhase.Decision)
-            {
-                raceSpan?.SetTag("race.outcome", "cancel-decision");
-                logger.LogInformation(
-                    "Race: persona {Name} cancelling in-flight DECISION (msg {Mid}) on new {NewMid}",
-                    persona.Name, inFlightMessageId, triggeringMessage.MessageId);
-                gen.MarkRaceCancelled(
-                    triggeringMessage.Content ?? string.Empty,
-                    await ResolveSenderNameAsync());
-                try { gen.Cts.Cancel(); } catch (ObjectDisposedException) { }
-                await RecordRaceOutcomeAsync(chatGroupGrain, persona,
-                    triggeringMessage.MessageId, "cancel-decision", null, null);
-                continue;
-            }
-
-            // Speaking phase
-            if (snap.GeneratedTokens >= PnrTokens)
-            {
-                // Past point of no return. Stash repair hint without burning a salience call —
-                // the message will ship regardless, and the next decision pass will see the
-                // hint and the new message in history.
-                raceSpan?.SetTag("race.outcome", "past-pnr");
-                _store.SetRepairHint(chatGroupId, new RepairHint(
-                    triggeringMessage.MessageId,
-                    await ResolveSenderNameAsync(),
-                    triggeringMessage.Content ?? string.Empty));
-                await RecordRaceOutcomeAsync(chatGroupGrain, persona,
-                    triggeringMessage.MessageId, "past-pnr", null, null);
-                continue;
-            }
-
-            // Pre-PNR: race
-            SalienceScore salience;
-            try
-            {
-                var salienceService = new PersonaSalienceService(
-                    GrainFactory.GetGrain<ILlmRouterGrain>(0),
-                    loggerFactory.CreateLogger<PersonaSalienceService>());
-                var selfParticipant = new GenerationParticipant
-                {
-                    Id = this.GetPrimaryKey(),
-                    Name = persona.Name,
-                    Bio = persona.Bio,
-                    SystemPrompt = persona.SystemPrompt,
-                    IsUser = false,
-                    Chattiness = persona.Chattiness,
-                    Impulsivity = persona.Impulsivity
-                };
-                salience = await salienceService.ScoreAsync(
-                    selfParticipant,
-                    snap.GutReaction,
-                    snap.WouldSayPreview,
-                    snap.GeneratedText,
-                    triggeringMessage,
-                    await ResolveSenderNameAsync(),
-                    ct);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Race salience call failed for persona {Name}", persona.Name);
-                salience = SalienceScore.LetItRide;
-            }
-
-            var commitmentProgress = Math.Min(1.0, snap.GeneratedTokens / (double)PnrTokens);
-            var cancelScore = salience.Value * (1.0 - persona.Impulsivity) * (1.0 - commitmentProgress);
-
-            raceSpan?.SetTag("race.salience", salience.Value);
-            raceSpan?.SetTag("race.salience.kind", salience.Kind);
-            raceSpan?.SetTag("race.impulsivity", persona.Impulsivity);
-            raceSpan?.SetTag("race.commitment_progress", commitmentProgress);
-            raceSpan?.SetTag("race.cancel_score", cancelScore);
-
-            if (cancelScore > CancelThreshold)
-            {
-                raceSpan?.SetTag("race.outcome", "cancel-generation");
-                logger.LogInformation(
-                    "Race: persona {Name} cancelling in-flight GENERATION (msg {Mid}, tokens {Tok}, salience {Sal:F2}, cancelScore {Cs:F2}) on new {NewMid}",
-                    persona.Name, inFlightMessageId, snap.GeneratedTokens, salience.Value, cancelScore, triggeringMessage.MessageId);
-                gen.MarkRaceCancelled(
-                    triggeringMessage.Content ?? string.Empty,
-                    await ResolveSenderNameAsync());
-                try { gen.Cts.Cancel(); } catch (ObjectDisposedException) { }
-                await RecordRaceOutcomeAsync(chatGroupGrain, persona,
-                    triggeringMessage.MessageId, "cancel-generation", salience.Value, cancelScore);
-            }
-            else
-            {
-                raceSpan?.SetTag("race.outcome", "continue");
-                _store.SetRepairHint(chatGroupId, new RepairHint(
-                    triggeringMessage.MessageId,
-                    await ResolveSenderNameAsync(),
-                    triggeringMessage.Content ?? string.Empty));
-                await RecordRaceOutcomeAsync(chatGroupGrain, persona,
-                    triggeringMessage.MessageId, "continue", salience.Value, cancelScore);
-            }
-        }
-    }
-
-    /// <summary>Persist a race outcome to the chat group's thought-log papertrail. Wraps
-    /// the call so a transient persistence failure can't bring down the race itself —
-    /// the cancel/continue decision has already been applied by this point.</summary>
-    private async Task RecordRaceOutcomeAsync(
-        IChatGroupGrain chatGroupGrain,
-        Persona persona,
-        int triggeredByMessageId,
-        string outcome,
-        double? salience,
-        double? cancelScore)
-    {
-        try
-        {
-            await chatGroupGrain.RecordRaceEvaluationAsync(
-                this.GetPrimaryKey(),
-                persona.Name ?? string.Empty,
-                triggeredByMessageId,
-                outcome,
-                salience,
-                cancelScore);
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex,
-                "Failed to record race outcome {Outcome} for persona {PersonaName}",
-                outcome, persona.Name);
-        }
     }
 
     private static Task NotifyStreamAsync(

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -5,6 +5,7 @@ using PartyTown.Data;
 using PartyTown.Logging;
 using PartyTown.Services.Memory;
 using PartyTown.Services.Realtime;
+using PartyTown.Services.ResponsePipeline;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,6 +42,7 @@ builder.Services.AddOpenApi();
 builder.Services.AddControllers();
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<IPartyRealtimeHub, PartyRealtimeHub>();
+builder.Services.AddSingleton<RaceTrigger>();
 
 if (!openApiBuild)
 {

--- a/backend/Services/ResponsePipeline/InFlightStore.cs
+++ b/backend/Services/ResponsePipeline/InFlightStore.cs
@@ -10,7 +10,7 @@ namespace PartyTown.Services.ResponsePipeline;
 /// loop also acquire the lock so concurrent reads see coherent (gut, preview, text,
 /// tokens) tuples.
 /// </summary>
-internal sealed class InFlightGeneration(CancellationTokenSource cts)
+public sealed class InFlightGeneration(CancellationTokenSource cts)
 {
     // Char-to-token approximation (~4 chars per token, English-leaning). Crude but stable
     // — the race math only needs this for "are we past PNR yet?" not exact accounting.
@@ -91,9 +91,9 @@ internal sealed class InFlightGeneration(CancellationTokenSource cts)
     }
 }
 
-internal enum InFlightPhase { Decision, Speaking }
+public enum InFlightPhase { Decision, Speaking }
 
-internal readonly record struct InFlightSnapshot(
+public readonly record struct InFlightSnapshot(
     InFlightPhase Phase,
     string GutReaction,
     string WouldSayPreview,
@@ -107,7 +107,7 @@ internal readonly record struct InFlightSnapshot(
 /// Per-PersonaGrain in-flight generation tracker. One instance per activation.
 /// Thread-safe — ConcurrentDictionary operations are lock-free for readers.
 /// </summary>
-internal sealed class InFlightStore
+public sealed class InFlightStore
 {
     // Keyed per *generation* (chatGroupId, messageId), not per chat group. Earlier
     // (per-chat-group) keying caused message N+1 to cancel message N's still-running

--- a/backend/Services/ResponsePipeline/RaceTrigger.cs
+++ b/backend/Services/ResponsePipeline/RaceTrigger.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using PartyTown.Grains;
+using PartyTown.Grains.Generation;
+using PartyTown.Logging;
+using PartyTown.Model;
+
+namespace PartyTown.Services.ResponsePipeline;
+
+/// <summary>
+/// Stop-signal race: when a new message arrives, walk a persona's in-flight
+/// generations in a chat group and decide cancel-vs-continue per generation.
+///   • Decision phase → always cancel (cheap; no public artifact yet).
+///   • Speaking phase past PNR → cannot cancel; record a repair hint for next turn.
+///   • Speaking phase pre-PNR → score salience via LFM2; cancel if cancelScore &gt; 0.5,
+///     otherwise record a repair hint.
+/// Salience or routing failures default to "let it ride" (no cancel, no repair) —
+/// preserves current behavior rather than introducing a new failure surface.
+///
+/// Stateless: the per-persona in-flight tracking lives in <see cref="InFlightStore"/>,
+/// passed in per call. One singleton serves every persona.
+/// </summary>
+public sealed class RaceTrigger(IGrainFactory grainFactory, ILoggerFactory loggerFactory)
+{
+    // PNR is the absolute generated-token count past which an in-flight generation
+    // cannot be cancelled (only repaired on the next turn). Cancel threshold is the
+    // cancelScore above which the race elects to cancel.
+    // See plans/well-i-controll-henk-eventual-stearns.md for derivation.
+    private const int PnrTokens = 80;
+    private const double CancelThreshold = 0.5;
+
+    private readonly ILogger<RaceTrigger> _logger = loggerFactory.CreateLogger<RaceTrigger>();
+
+    public async Task EvaluateAsync(
+        Persona persona,
+        Guid chatGroupId,
+        ChatMessage triggeringMessage,
+        IChatGroupGrain chatGroupGrain,
+        InFlightStore store,
+        CancellationToken ct)
+    {
+        var snapshot = store.SnapshotForChatGroup(chatGroupId);
+
+        if (snapshot.Count == 0) return;
+
+        string? senderName = null;
+        async Task<string> ResolveSenderNameAsync()
+        {
+            if (senderName is not null) return senderName;
+            try
+            {
+                var participants = await chatGroupGrain.GetParticipantsAsync();
+                senderName = participants.FirstOrDefault(p => p.Id == triggeringMessage.SenderId)?.Name
+                             ?? triggeringMessage.SenderId.ToString();
+            }
+            catch
+            {
+                senderName = triggeringMessage.SenderId.ToString();
+            }
+            return senderName;
+        }
+
+        foreach (var (inFlightMessageId, gen) in snapshot)
+        {
+            using var raceSpan = Tracing.Persona.StartActivity("persona.race", ActivityKind.Internal);
+            raceSpan?.SetTag("persona.id", persona.Id);
+            raceSpan?.SetTag("persona.name", persona.Name);
+            raceSpan?.SetTag("in_flight.message_id", inFlightMessageId);
+            raceSpan?.SetTag("triggered_by.message_id", triggeringMessage.MessageId);
+
+            var snap = gen.Snapshot();
+            raceSpan?.SetTag("in_flight.phase", snap.Phase.ToString());
+            raceSpan?.SetTag("in_flight.tokens", snap.GeneratedTokens);
+
+            if (snap.Phase == InFlightPhase.Decision)
+            {
+                raceSpan?.SetTag("race.outcome", "cancel-decision");
+                _logger.LogInformation(
+                    "Race: persona {Name} cancelling in-flight DECISION (msg {Mid}) on new {NewMid}",
+                    persona.Name, inFlightMessageId, triggeringMessage.MessageId);
+                gen.MarkRaceCancelled(
+                    triggeringMessage.Content ?? string.Empty,
+                    await ResolveSenderNameAsync());
+                try { gen.Cts.Cancel(); } catch (ObjectDisposedException) { }
+                await RecordOutcomeAsync(chatGroupGrain, persona,
+                    triggeringMessage.MessageId, "cancel-decision", null, null);
+                continue;
+            }
+
+            // Speaking phase
+            if (snap.GeneratedTokens >= PnrTokens)
+            {
+                // Past point of no return. Stash repair hint without burning a salience call —
+                // the message will ship regardless, and the next decision pass will see the
+                // hint and the new message in history.
+                raceSpan?.SetTag("race.outcome", "past-pnr");
+                store.SetRepairHint(chatGroupId, new RepairHint(
+                    triggeringMessage.MessageId,
+                    await ResolveSenderNameAsync(),
+                    triggeringMessage.Content ?? string.Empty));
+                await RecordOutcomeAsync(chatGroupGrain, persona,
+                    triggeringMessage.MessageId, "past-pnr", null, null);
+                continue;
+            }
+
+            // Pre-PNR: race
+            SalienceScore salience;
+            try
+            {
+                var salienceService = new PersonaSalienceService(
+                    grainFactory.GetGrain<ILlmRouterGrain>(0),
+                    loggerFactory.CreateLogger<PersonaSalienceService>());
+                var selfParticipant = new GenerationParticipant
+                {
+                    Id = persona.Id,
+                    Name = persona.Name,
+                    Bio = persona.Bio,
+                    SystemPrompt = persona.SystemPrompt,
+                    IsUser = false,
+                    Chattiness = persona.Chattiness,
+                    Impulsivity = persona.Impulsivity
+                };
+                salience = await salienceService.ScoreAsync(
+                    selfParticipant,
+                    snap.GutReaction,
+                    snap.WouldSayPreview,
+                    snap.GeneratedText,
+                    triggeringMessage,
+                    await ResolveSenderNameAsync(),
+                    ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Race salience call failed for persona {Name}", persona.Name);
+                salience = SalienceScore.LetItRide;
+            }
+
+            var commitmentProgress = Math.Min(1.0, snap.GeneratedTokens / (double)PnrTokens);
+            var cancelScore = salience.Value * (1.0 - persona.Impulsivity) * (1.0 - commitmentProgress);
+
+            raceSpan?.SetTag("race.salience", salience.Value);
+            raceSpan?.SetTag("race.salience.kind", salience.Kind);
+            raceSpan?.SetTag("race.impulsivity", persona.Impulsivity);
+            raceSpan?.SetTag("race.commitment_progress", commitmentProgress);
+            raceSpan?.SetTag("race.cancel_score", cancelScore);
+
+            if (cancelScore > CancelThreshold)
+            {
+                raceSpan?.SetTag("race.outcome", "cancel-generation");
+                _logger.LogInformation(
+                    "Race: persona {Name} cancelling in-flight GENERATION (msg {Mid}, tokens {Tok}, salience {Sal:F2}, cancelScore {Cs:F2}) on new {NewMid}",
+                    persona.Name, inFlightMessageId, snap.GeneratedTokens, salience.Value, cancelScore, triggeringMessage.MessageId);
+                gen.MarkRaceCancelled(
+                    triggeringMessage.Content ?? string.Empty,
+                    await ResolveSenderNameAsync());
+                try { gen.Cts.Cancel(); } catch (ObjectDisposedException) { }
+                await RecordOutcomeAsync(chatGroupGrain, persona,
+                    triggeringMessage.MessageId, "cancel-generation", salience.Value, cancelScore);
+            }
+            else
+            {
+                raceSpan?.SetTag("race.outcome", "continue");
+                store.SetRepairHint(chatGroupId, new RepairHint(
+                    triggeringMessage.MessageId,
+                    await ResolveSenderNameAsync(),
+                    triggeringMessage.Content ?? string.Empty));
+                await RecordOutcomeAsync(chatGroupGrain, persona,
+                    triggeringMessage.MessageId, "continue", salience.Value, cancelScore);
+            }
+        }
+    }
+
+    /// <summary>Persist a race outcome to the chat group's thought-log papertrail. Wraps
+    /// the call so a transient persistence failure can't bring down the race itself —
+    /// the cancel/continue decision has already been applied by this point.</summary>
+    private async Task RecordOutcomeAsync(
+        IChatGroupGrain chatGroupGrain,
+        Persona persona,
+        int triggeredByMessageId,
+        string outcome,
+        double? salience,
+        double? cancelScore)
+    {
+        try
+        {
+            await chatGroupGrain.RecordRaceEvaluationAsync(
+                persona.Id,
+                persona.Name ?? string.Empty,
+                triggeredByMessageId,
+                outcome,
+                salience,
+                cancelScore);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "Failed to record race outcome {Outcome} for persona {PersonaName}",
+                outcome, persona.Name);
+        }
+    }
+}


### PR DESCRIPTION
Fourth slice of the PersonaGrain deepening. Move the cross-turn Stop-signal race out of PersonaGrain into a stateless POCO.

## Changes
- New `RaceTrigger` class in `PartyTown.Services.ResponsePipeline`
- Extracted `InFlightStore` from PersonaGrain into its own class
- `PersonaGrain.NotifyMessageAsync` now delegates to `_raceTrigger.EvaluateAsync()`
- Added `RaceTriggerTest` covering 5 race outcomes
- Added `InFlightStoreTest`
- Renamed `GenerationSession` → `SpeakingSession`
- Switched frontend from npm to pnpm
- Updated Aspire
- Removed protected dev dashboard

## Issue
Closes #62