### PR TITLE
Bench probe improvements + intrinsic stance promotion

### DIFF
--- a/backend-test/Infrastructure/MemoryGraphFixture.cs
+++ b/backend-test/Infrastructure/MemoryGraphFixture.cs
@@ -45,7 +45,9 @@ public sealed class MemoryGraphFixture : IAsyncLifetime
                 await cmd.ExecuteNonQueryAsync();
             }
 
-            await EnsureMemoryGraphSchemaAsync(probe);
+            // Dev Postgres already ran 05-age-setup.sql + 06-memory-graph.sql; this re-ensures the
+            // graph idempotently so a freshly-reset volume (or a partial init) still passes.
+            await MemoryGraphSchema.EnsureAsync(probe);
             IsAvailable = true;
         }
         catch (Exception ex)
@@ -56,63 +58,6 @@ public sealed class MemoryGraphFixture : IAsyncLifetime
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
-
-    private static async Task EnsureMemoryGraphSchemaAsync(NpgsqlConnection conn)
-    {
-        // Idempotent schema: matches docker-entrypoint-initdb.d/06-memory-graph.sql for
-        // graph + labels (reshaped per ADR 0014 — no Party/Room/Message vertices, no
-        // IN_PARTY/ANCHORED_TO edges). Indexes in the docker init script are perf-only and
-        // skipped here; tests pass without them.
-        // create_vlabel/create_elabel are cstring-typed, so cast explicitly.
-        const string ddl = """
-            LOAD 'age';
-            SET search_path = ag_catalog, "$user", public;
-
-            DO $$
-            BEGIN
-              IF NOT EXISTS (SELECT 1 FROM ag_catalog.ag_graph WHERE name = 'memory') THEN
-                PERFORM ag_catalog.create_graph('memory');
-              END IF;
-            END
-            $$;
-
-            DO $$
-            DECLARE
-              lbl text;
-            BEGIN
-              FOREACH lbl IN ARRAY ARRAY['Persona','Participant','Concept','Event']
-              LOOP
-                IF NOT EXISTS (
-                  SELECT 1 FROM ag_catalog.ag_label
-                   WHERE name = lbl AND graph = (SELECT graphid FROM ag_catalog.ag_graph WHERE name = 'memory')
-                ) THEN
-                  PERFORM ag_catalog.create_vlabel('memory'::cstring, lbl::cstring);
-                END IF;
-              END LOOP;
-            END
-            $$;
-
-            DO $$
-            DECLARE
-              lbl text;
-            BEGIN
-              FOREACH lbl IN ARRAY ARRAY['HAS_PARTICIPANT','RECOLLECTS','ABOUT','STANCE']
-              LOOP
-                IF NOT EXISTS (
-                  SELECT 1 FROM ag_catalog.ag_label
-                   WHERE name = lbl AND graph = (SELECT graphid FROM ag_catalog.ag_graph WHERE name = 'memory')
-                ) THEN
-                  PERFORM ag_catalog.create_elabel('memory'::cstring, lbl::cstring);
-                END IF;
-              END LOOP;
-            END
-            $$;
-            """;
-
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = ddl;
-        await cmd.ExecuteNonQueryAsync();
-    }
 
     private sealed class TestDbContextFactory(DbContextOptions<AppDbContext> options)
         : IDbContextFactory<AppDbContext>

--- a/backend-test/IntrinsicStanceIntegrationTest.cs
+++ b/backend-test/IntrinsicStanceIntegrationTest.cs
@@ -1,0 +1,348 @@
+using BackendTest.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using PartyTown.Model;
+using PartyTown.Services.Memory;
+
+namespace BackendTest;
+
+/// <summary>
+/// Integration tests for Intrinsic Stance (ADR 0016, issue #91): Persona-scope STANCE edges,
+/// union read across Acquired + Intrinsic, Promotion with Participant→Persona re-targeting.
+/// Requires the dev Postgres+AGE instance (Aspire AppHost).
+/// </summary>
+public sealed class IntrinsicStanceIntegrationTest(MemoryGraphFixture fixture)
+    : IClassFixture<MemoryGraphFixture>
+{
+    private MemoryRepository MakeRepo()
+        => new(fixture.Factory, NullExtractor.Instance, NullLogger<MemoryRepository>.Instance);
+
+    private void RequireDevStack()
+    {
+        if (!fixture.IsAvailable)
+        {
+            throw new InvalidOperationException(
+                $"Dev Postgres+AGE unavailable: {fixture.UnavailableReason}. " +
+                "Start the Aspire AppHost (`dotnet run --project aspire/Proompting.AppHost`) and rerun.");
+        }
+    }
+
+    // ─── Authoring and listing ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AppendIntrinsic_AppearsInListIntrinsicStances()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var personaB = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        var id = await repo.AppendIntrinsicStanceAsync(
+            personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.7, reasoning: "Vlad impresses you", attribution: null,
+            CancellationToken.None);
+
+        var stances = await repo.ListIntrinsicStancesAsync(personaA, CancellationToken.None);
+
+        var record = Assert.Single(stances);
+        Assert.Equal(id, record.Id);
+        Assert.Equal(0.7, record.Valence, precision: 4);
+        Assert.Equal("Vlad impresses you", record.Reasoning);
+        Assert.Equal(StanceTargetKind.Participant, record.TargetKind);
+        Assert.Equal(personaB, record.TargetPersonaId);
+        Assert.True(record.IsCurrent);
+        Assert.True(record.IsIntrinsic);
+    }
+
+    [Fact]
+    public async Task AppendIntrinsicSelf_TargetKindIsSelf()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        await repo.AppendIntrinsicStanceAsync(
+            personaA,
+            new StanceTargetSpec(StanceTargetKind.Self, null, null, null),
+            valence: 0.3, reasoning: "you doubt yourself sometimes", attribution: null,
+            CancellationToken.None);
+
+        var stances = await repo.ListIntrinsicStancesAsync(personaA, CancellationToken.None);
+
+        var record = Assert.Single(stances);
+        Assert.Equal(StanceTargetKind.Self, record.TargetKind);
+        Assert.Equal(personaA, record.TargetPersonaId);
+        Assert.True(record.IsIntrinsic);
+    }
+
+    // ─── Union read: Intrinsic renders in any Party ────────────────────────────────────────
+
+    [Fact]
+    public async Task IntrinsicStance_RendersInAnyPartyWhenTargetPresent()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var personaB = Guid.NewGuid();
+        var partyId1 = Guid.NewGuid();
+        var partyId2 = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        await repo.AppendIntrinsicStanceAsync(
+            personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.8, reasoning: "you trust Vlad's instincts", attribution: null,
+            CancellationToken.None);
+
+        // Party 1: both present
+        var lines1 = await repo.RecallStancesAsync(
+            partyId1, personaA, new[] { personaA, personaB }, anchorText: "", limit: 10,
+            CancellationToken.None);
+
+        // Party 2: both present
+        var lines2 = await repo.RecallStancesAsync(
+            partyId2, personaA, new[] { personaA, personaB }, anchorText: "", limit: 10,
+            CancellationToken.None);
+
+        Assert.Single(lines1);
+        Assert.Equal("you trust Vlad's instincts", lines1[0].Reasoning);
+        Assert.Single(lines2);
+        Assert.Equal("you trust Vlad's instincts", lines2[0].Reasoning);
+    }
+
+    [Fact]
+    public async Task IntrinsicStance_RendersNothingWhenTargetAbsent()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var personaB = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        await repo.AppendIntrinsicStanceAsync(
+            personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.8, reasoning: "you trust Vlad's instincts", attribution: null,
+            CancellationToken.None);
+
+        // personaB is NOT in presentPersonaIds
+        var lines = await repo.RecallStancesAsync(
+            partyId, personaA, new[] { personaA }, anchorText: "", limit: 10,
+            CancellationToken.None);
+
+        Assert.Empty(lines);
+    }
+
+    // ─── Union read: Acquired overrides Intrinsic in the same Party ───────────────────────
+
+    [Fact]
+    public async Task AcquiredStance_OverridesIntrinsicInSameParty_NotInOther()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var personaB = Guid.NewGuid();
+        var partyId1 = Guid.NewGuid();
+        var partyId2 = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        // Intrinsic first (older).
+        await repo.AppendIntrinsicStanceAsync(
+            personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.3, reasoning: "old intrinsic baseline", attribution: null,
+            CancellationToken.None);
+
+        // Acquired in Party 1 (newer — inserted after).
+        await repo.AppendStanceAsync(
+            partyId1, personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.9, reasoning: "newer party-1 acquired", attribution: null,
+            CancellationToken.None);
+
+        var present = new[] { personaA, personaB };
+
+        // Party 1: the newer Acquired wins.
+        var lines1 = await repo.RecallStancesAsync(
+            partyId1, personaA, present, anchorText: "", limit: 10,
+            CancellationToken.None);
+
+        // Party 2: only Intrinsic (no Acquired written there).
+        var lines2 = await repo.RecallStancesAsync(
+            partyId2, personaA, present, anchorText: "", limit: 10,
+            CancellationToken.None);
+
+        Assert.Single(lines1);
+        Assert.Equal("newer party-1 acquired", lines1[0].Reasoning);
+        Assert.Single(lines2);
+        Assert.Equal("old intrinsic baseline", lines2[0].Reasoning);
+    }
+
+    // ─── Promotion ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Promote_ParticipantTarget_ReTargetsPersona_ResolvesInOtherParty()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var personaB = Guid.NewGuid();
+        var partyId1 = Guid.NewGuid();
+        var partyId2 = Guid.NewGuid();
+        var partyId3 = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        // Acquire stance in Party 1: personaA toward personaB (Participant).
+        var acquiredId = await repo.AppendStanceAsync(
+            partyId1, personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.6, reasoning: "promoted persona stance", attribution: null,
+            CancellationToken.None);
+
+        // Promote to Intrinsic scope.
+        var intrinsicId = await repo.PromoteStanceAsync(partyId1, personaA, acquiredId, CancellationToken.None);
+        Assert.NotNull(intrinsicId);
+
+        // Intrinsic list now has one entry targeting personaB.
+        var intrinsicList = await repo.ListIntrinsicStancesAsync(personaA, CancellationToken.None);
+        var intrinsicRecord = Assert.Single(intrinsicList);
+        Assert.Equal(intrinsicId.Value, intrinsicRecord.Id);
+        Assert.Equal(personaB, intrinsicRecord.TargetPersonaId);
+        Assert.Equal("promoted persona stance", intrinsicRecord.Reasoning);
+        Assert.True(intrinsicRecord.IsIntrinsic);
+
+        // Party 2: personaA and personaB present → intrinsic renders.
+        var lines2 = await repo.RecallStancesAsync(
+            partyId2, personaA, new[] { personaA, personaB }, anchorText: "", limit: 10,
+            CancellationToken.None);
+        Assert.Single(lines2);
+        Assert.Equal("promoted persona stance", lines2[0].Reasoning);
+
+        // Party 3: only personaA present, personaB absent → renders nothing.
+        var lines3 = await repo.RecallStancesAsync(
+            partyId3, personaA, new[] { personaA }, anchorText: "", limit: 10,
+            CancellationToken.None);
+        Assert.Empty(lines3);
+    }
+
+    [Fact]
+    public async Task Promote_ConceptTarget_CarriesOverUnchanged()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var conceptName = $"lisp-{Guid.NewGuid():N}";
+        var conceptDisplay = $"Lisp-{Guid.NewGuid():N}";
+        var repo = MakeRepo();
+
+        var acquiredId = await repo.AppendStanceAsync(
+            partyId, personaA,
+            new StanceTargetSpec(StanceTargetKind.Concept, null, conceptName, conceptDisplay),
+            valence: 0.9, reasoning: "you love Lisp", attribution: null,
+            CancellationToken.None);
+
+        var intrinsicId = await repo.PromoteStanceAsync(partyId, personaA, acquiredId, CancellationToken.None);
+        Assert.NotNull(intrinsicId);
+
+        var intrinsicList = await repo.ListIntrinsicStancesAsync(personaA, CancellationToken.None);
+        var record = Assert.Single(intrinsicList);
+        Assert.Equal(StanceTargetKind.Concept, record.TargetKind);
+        Assert.Equal(conceptName, record.TargetConceptName);
+        Assert.True(record.IsIntrinsic);
+    }
+
+    [Fact]
+    public async Task Promote_SelfTarget_CarriesOverUnchanged()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        var acquiredId = await repo.AppendStanceAsync(
+            partyId, personaA,
+            new StanceTargetSpec(StanceTargetKind.Self, null, null, null),
+            valence: -0.2, reasoning: "you doubt yourself", attribution: null,
+            CancellationToken.None);
+
+        var intrinsicId = await repo.PromoteStanceAsync(partyId, personaA, acquiredId, CancellationToken.None);
+        Assert.NotNull(intrinsicId);
+
+        var intrinsicList = await repo.ListIntrinsicStancesAsync(personaA, CancellationToken.None);
+        var record = Assert.Single(intrinsicList);
+        Assert.Equal(StanceTargetKind.Self, record.TargetKind);
+        Assert.Equal(personaA, record.TargetPersonaId);
+        Assert.True(record.IsIntrinsic);
+    }
+
+    [Fact]
+    public async Task Promote_LeavesOriginalAcquiredEdgeIntact()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var personaB = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        var acquiredId = await repo.AppendStanceAsync(
+            partyId, personaA,
+            new StanceTargetSpec(StanceTargetKind.Participant, personaB, null, null),
+            valence: 0.5, reasoning: "original acquired", attribution: null,
+            CancellationToken.None);
+
+        await repo.PromoteStanceAsync(partyId, personaA, acquiredId, CancellationToken.None);
+
+        // The Acquired Stance edge must still be present and unchanged.
+        var acquiredList = await repo.ListStancesAsync(partyId, personaA, CancellationToken.None);
+        var acquired = Assert.Single(acquiredList);
+        Assert.Equal(acquiredId, acquired.Id);
+        Assert.Equal("original acquired", acquired.Reasoning);
+        Assert.False(acquired.IsIntrinsic);
+    }
+
+    [Fact]
+    public async Task Promote_UnknownStanceId_ReturnsNull()
+    {
+        RequireDevStack();
+
+        var personaA = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var repo = MakeRepo();
+
+        var result = await repo.PromoteStanceAsync(partyId, personaA, Guid.NewGuid(), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    // ─── NullExtractor (re-used from parent test class pattern) ───────────────────────────
+
+    private sealed class NullExtractor : IMemoryExtractor
+    {
+        public static readonly NullExtractor Instance = new();
+
+        public Task<EventExtraction?> ExtractEventAsync(
+            ChatMessage sourceMessage,
+            string sourceAuthorName,
+            IReadOnlyList<ChatMessage> recentContext,
+            IReadOnlyList<ParticipantView> presentParticipants,
+            IReadOnlyList<string> existingConcepts,
+            Func<Guid, string> resolveAuthorName,
+            CancellationToken cancellationToken) => Task.FromResult<EventExtraction?>(null);
+
+        public Task<IReadOnlyDictionary<Guid, RecollectionDraft>> ExtractRecollectionsAsync(
+            IReadOnlyList<RecollectionTarget> targets,
+            ChatMessage sourceMessage,
+            string sourceAuthorName,
+            IReadOnlyList<ChatMessage> recentContext,
+            Func<Guid, string> resolveAuthorName,
+            CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyDictionary<Guid, RecollectionDraft>>(
+                new Dictionary<Guid, RecollectionDraft>());
+    }
+}

--- a/backend/Controllers/MemoryController.cs
+++ b/backend/Controllers/MemoryController.cs
@@ -194,6 +194,27 @@ public sealed class MemoryController(
         var stances = await memoryRepository.ListStancesAsync(partyId, personaId, ct);
         return Ok(stances);
     }
+
+    /// <summary>
+    /// Promote an Acquired Stance to Intrinsic (Persona) scope (ADR 0016): write a new
+    /// Persona-scope edge carrying the current projection. A Participant target is
+    /// re-pointed at the target's underlying Persona so the edge is meaningful across
+    /// Parties. The original Acquired edge is not touched.
+    /// </summary>
+    [HttpPost("participants/{personaId:guid}/stances/{stanceId:guid}/promote")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AppendStanceResponse>> PromoteStance(
+        Guid partyId, Guid personaId, Guid stanceId, CancellationToken ct)
+    {
+        var id = await memoryRepository.PromoteStanceAsync(partyId, personaId, stanceId, ct);
+        if (id is null)
+        {
+            return NotFound("No such stance authored by this participant.");
+        }
+        return CreatedAtAction(
+            nameof(ListStances), new { partyId, personaId }, new AppendStanceResponse(id.Value));
+    }
 }
 
 /// <summary>

--- a/backend/Controllers/PersonaController.cs
+++ b/backend/Controllers/PersonaController.cs
@@ -522,6 +522,11 @@ public class PersonaController(
                 {
                     return BadRequest("A Concept Stance requires targetConceptName.");
                 }
+                if (display.Length > MemoryExtractor.MaxConceptNameChars)
+                {
+                    return BadRequest(
+                        $"Concept name must be at most {MemoryExtractor.MaxConceptNameChars} characters.");
+                }
                 target = new StanceTargetSpec(
                     StanceTargetKind.Concept, null,
                     MemoryExtractor.NormaliseConceptName(display), display);

--- a/backend/Controllers/PersonaController.cs
+++ b/backend/Controllers/PersonaController.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Caching.Memory;
 using PartyTown.Grains;
 using PartyTown.Grains.Generation;
 using PartyTown.Model;
+using PartyTown.Services.Memory;
 using PartyTown.Services.Realtime;
 
 namespace PartyTown.Controllers;
@@ -49,6 +50,7 @@ public class PersonaController(
     IGrainFactory grains,
     IMemoryCache cache,
     IWebHostEnvironment env,
+    IMemoryRepository memoryRepository,
     ILogger<PersonaController> logger) : ControllerBase
 {
     private const string BioGenerationSystemPrompt =
@@ -449,5 +451,93 @@ public class PersonaController(
             bio = $"A unique AI persona named {name}.";
 
         return (name, systemPrompt, bio);
+    }
+
+    // ─── Intrinsic Stances (ADR 0016, issue #91) ──────────────────────────────────────────
+
+    private const int MaxReasoningLength = 600;
+
+    /// <summary>
+    /// Every Intrinsic Stance authored at Persona (library) scope, newest first. The latest
+    /// edge per target is flagged <see cref="StanceRecord.IsCurrent"/>; superseded edges
+    /// remain for history.
+    /// </summary>
+    [HttpGet("{personaId:guid}/stances")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<StanceRecord>>> ListIntrinsicStances(
+        Guid personaId, CancellationToken ct)
+    {
+        var stances = await memoryRepository.ListIntrinsicStancesAsync(personaId, ct);
+        return Ok(stances);
+    }
+
+    /// <summary>
+    /// Append an Intrinsic Stance at Persona (library) scope. The edge travels into every
+    /// Party the Persona joins. Append-only — prior edges are not mutated.
+    /// </summary>
+    [HttpPost("{personaId:guid}/stances")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<AppendStanceResponse>> AppendIntrinsicStance(
+        Guid personaId, [FromBody] AppendStanceRequest request, CancellationToken ct)
+    {
+        if (request is null)
+        {
+            return BadRequest("Missing request body.");
+        }
+
+        if (double.IsNaN(request.Valence) || request.Valence < -1.0 || request.Valence > 1.0)
+        {
+            return BadRequest("Valence must be a number in the range -1..1.");
+        }
+
+        var reasoning = request.Reasoning?.Trim();
+        if (string.IsNullOrEmpty(reasoning))
+        {
+            return BadRequest("Reasoning is required.");
+        }
+        if (reasoning.Length > MaxReasoningLength)
+        {
+            return BadRequest($"Reasoning must be at most {MaxReasoningLength} characters.");
+        }
+
+        StanceTargetSpec target;
+        switch (request.TargetKind)
+        {
+            case StanceTargetKind.Participant:
+                if (request.TargetPersonaId is not Guid targetPersonaId || targetPersonaId == Guid.Empty)
+                {
+                    return BadRequest("A Participant Stance requires targetPersonaId (the target Persona's id).");
+                }
+                if (targetPersonaId == personaId)
+                {
+                    return BadRequest("Use TargetKind.Self to record a stance toward oneself.");
+                }
+                target = new StanceTargetSpec(StanceTargetKind.Participant, targetPersonaId, null, null);
+                break;
+
+            case StanceTargetKind.Concept:
+                var display = request.TargetConceptName?.Trim();
+                if (string.IsNullOrEmpty(display))
+                {
+                    return BadRequest("A Concept Stance requires targetConceptName.");
+                }
+                target = new StanceTargetSpec(
+                    StanceTargetKind.Concept, null,
+                    MemoryExtractor.NormaliseConceptName(display), display);
+                break;
+
+            case StanceTargetKind.Self:
+                target = new StanceTargetSpec(StanceTargetKind.Self, null, null, null);
+                break;
+
+            default:
+                return BadRequest("Unknown stance target kind.");
+        }
+
+        var id = await memoryRepository.AppendIntrinsicStanceAsync(
+            personaId, target, request.Valence, reasoning, attribution: null, ct);
+        return CreatedAtAction(
+            nameof(ListIntrinsicStances), new { personaId }, new AppendStanceResponse(id));
     }
 }

--- a/backend/Data/MemoryGraphSchema.cs
+++ b/backend/Data/MemoryGraphSchema.cs
@@ -1,0 +1,76 @@
+using Npgsql;
+
+namespace PartyTown.Data;
+
+/// <summary>
+/// Idempotent builder for the <c>memory</c> graph schema, shared by every consumer that talks to
+/// an AGE database the Aspire AppHost did <em>not</em> initialise: <c>backend-test</c>'s
+/// <c>MemoryGraphFixture</c> (dev Postgres, schema already present → no-op) and the bench's
+/// ephemeral Testcontainers AGE (bare container → this is the only place the graph gets built).
+/// </summary>
+/// <remarks>
+/// Mirrors <c>docker-entrypoint-initdb.d/06-memory-graph.sql</c> for the graph + labels (reshaped
+/// per ADR 0014 — no Party/Room/Message vertices, no IN_PARTY/ANCHORED_TO edges). The perf-only
+/// indexes in the docker init script are skipped; correctness does not depend on them.
+/// <para>
+/// This ensures the graph object only — it assumes the AGE extension is present and the
+/// <c>search_path</c> resolves <c>ag_catalog</c>. Against the Aspire DB that is true
+/// (<c>05-age-setup.sql</c>); a bare container must run that bring-up first (see the bench's
+/// <c>BenchMemory.PrepareAsync</c>).
+/// </para>
+/// </remarks>
+public static class MemoryGraphSchema
+{
+    public static async Task EnsureAsync(NpgsqlConnection conn, CancellationToken ct = default)
+    {
+        // create_vlabel/create_elabel are cstring-typed, so cast explicitly.
+        const string ddl = """
+            LOAD 'age';
+            SET search_path = ag_catalog, "$user", public;
+
+            DO $$
+            BEGIN
+              IF NOT EXISTS (SELECT 1 FROM ag_catalog.ag_graph WHERE name = 'memory') THEN
+                PERFORM ag_catalog.create_graph('memory');
+              END IF;
+            END
+            $$;
+
+            DO $$
+            DECLARE
+              lbl text;
+            BEGIN
+              FOREACH lbl IN ARRAY ARRAY['Persona','Participant','Concept','Event']
+              LOOP
+                IF NOT EXISTS (
+                  SELECT 1 FROM ag_catalog.ag_label
+                   WHERE name = lbl AND graph = (SELECT graphid FROM ag_catalog.ag_graph WHERE name = 'memory')
+                ) THEN
+                  PERFORM ag_catalog.create_vlabel('memory'::cstring, lbl::cstring);
+                END IF;
+              END LOOP;
+            END
+            $$;
+
+            DO $$
+            DECLARE
+              lbl text;
+            BEGIN
+              FOREACH lbl IN ARRAY ARRAY['HAS_PARTICIPANT','RECOLLECTS','ABOUT','STANCE']
+              LOOP
+                IF NOT EXISTS (
+                  SELECT 1 FROM ag_catalog.ag_label
+                   WHERE name = lbl AND graph = (SELECT graphid FROM ag_catalog.ag_graph WHERE name = 'memory')
+                ) THEN
+                  PERFORM ag_catalog.create_elabel('memory'::cstring, lbl::cstring);
+                END IF;
+              END LOOP;
+            END
+            $$;
+            """;
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = ddl;
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/backend/Services/Memory/IMemoryRepository.cs
+++ b/backend/Services/Memory/IMemoryRepository.cs
@@ -175,4 +175,58 @@ public interface IMemoryRepository
     /// API. Snapshot only — no streaming.
     /// </summary>
     Task<MemoryGraphDto> GetPartyMemoryGraphAsync(Guid partyId, CancellationToken ct);
+
+    // ─── Intrinsic Stances (ADR 0016, issue #91) ──────────────────────────────────────────
+
+    /// <summary>
+    /// Append one Intrinsic Stance at Persona (library) scope — a <c>(:Persona)-[:STANCE]</c>
+    /// edge that travels into every Party the Persona joins. Append-only, same latest-wins
+    /// rule as Acquired. The curator authors these in the persona-management UI; Promotion
+    /// lifts an Acquired Stance to this scope.
+    /// </summary>
+    /// <param name="personaId">The authoring Persona's library id.</param>
+    /// <param name="target">
+    /// Target shape. For <see cref="StanceTargetKind.Participant"/>, <c>PersonaId</c> names
+    /// the target Persona (not a Participant) — on promotion the caller has already resolved
+    /// the Participant's underlying Persona id. <see cref="StanceTargetKind.Self"/> writes a
+    /// self-loop on the Persona node.
+    /// </param>
+    /// <returns>The new edge's stable <c>id</c>.</returns>
+    Task<Guid> AppendIntrinsicStanceAsync(
+        Guid personaId,
+        StanceTargetSpec target,
+        double valence,
+        string reasoning,
+        StanceAttribution? attribution,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Every Intrinsic Stance edge authored at Persona scope, newest first. Mirrors
+    /// <see cref="ListStancesAsync"/> but reads from the Persona node rather than a
+    /// Participant. <see cref="StanceRecord.IsCurrent"/> marks the latest-wins survivor per
+    /// target; superseded edges are returned for history.
+    /// </summary>
+    Task<IReadOnlyList<StanceRecord>> ListIntrinsicStancesAsync(
+        Guid personaId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Promote an Acquired Stance to Intrinsic scope (ADR 0016): write a new Persona-scope
+    /// edge carrying the current projection; the original Acquired edge is untouched. If the
+    /// Acquired Stance targets a Participant, the target is re-pointed to that Participant's
+    /// underlying Persona so the edge is meaningful across Parties. Concept and self targets
+    /// carry over unchanged.
+    /// </summary>
+    /// <param name="partyId">Party scope for resolving the Acquired Stance.</param>
+    /// <param name="sourcePersonaId">Persona id of the Participant who owns the Acquired Stance.</param>
+    /// <param name="stanceId">The Acquired Stance edge id to promote.</param>
+    /// <returns>
+    /// The new Intrinsic edge's id, or <c>null</c> when <paramref name="stanceId"/> is not an
+    /// edge authored by this Participant in this Party.
+    /// </returns>
+    Task<Guid?> PromoteStanceAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        Guid stanceId,
+        CancellationToken ct);
 }

--- a/backend/Services/Memory/MemoryRepository.cs
+++ b/backend/Services/Memory/MemoryRepository.cs
@@ -981,9 +981,21 @@ public sealed class MemoryRepository(
                 StanceTargetKind.Participant, targetPersonaId, null, null);
         }
 
+        // Carry the source edge's provenance onto the promoted intrinsic edge so the
+        // audit trail survives — a promoted Consolidation/Retract edge must not read as
+        // curator-authored. Curator-origin edges keep attribution null.
+        var attribution = original.Origin switch
+        {
+            StanceOrigin.Consolidation => new StanceAttribution(
+                StanceOrigin.Consolidation, RunId: original.RunId),
+            StanceOrigin.Retract => new StanceAttribution(
+                StanceOrigin.Retract, RetractsId: original.RetractsId),
+            _ => null,
+        };
+
         return await AppendIntrinsicStanceAsync(
             sourcePersonaId, intrinsicTarget, original.Valence, original.Reasoning,
-            attribution: null, ct);
+            attribution, ct);
     }
 
     // All Intrinsic STANCE edges from one Persona node, newest first. Mirrors

--- a/backend/Services/Memory/MemoryRepository.cs
+++ b/backend/Services/Memory/MemoryRepository.cs
@@ -650,7 +650,15 @@ public sealed class MemoryRepository(
             return Array.Empty<StanceLine>();
         }
 
-        var rows = await FetchStanceEdgesAsync(partyId, sourcePersonaId, ct);
+        // Union Acquired (Participant-scope) + Intrinsic (Persona-scope) edges; latest-wins
+        // across both scopes per (source, target) key — ADR 0016 Intrinsic Stance slice.
+        var acquiredRows = await FetchStanceEdgesAsync(partyId, sourcePersonaId, ct);
+        var intrinsicRows = await FetchIntrinsicStanceEdgesAsync(sourcePersonaId, ct);
+        var rows = acquiredRows.Count == 0
+            ? intrinsicRows
+            : intrinsicRows.Count == 0
+                ? acquiredRows
+                : acquiredRows.Concat(intrinsicRows).OrderByDescending(r => r.Ts).ToList();
         var present = new HashSet<Guid>(presentPersonaIds);
         var text = anchorText ?? string.Empty;
 
@@ -756,19 +764,19 @@ public sealed class MemoryRepository(
     private static string TargetKey(StanceEdgeRow row)
         => row.TargetPersonaId is Guid tp ? $"p:{tp}" : $"c:{row.ConceptName}";
 
-    private static StanceRecord ToRecord(StanceEdgeRow row, Guid sourcePersonaId, bool isCurrent)
+    private static StanceRecord ToRecord(StanceEdgeRow row, Guid sourcePersonaId, bool isCurrent, bool isIntrinsic = false)
     {
         if (row.TargetPersonaId is Guid tp)
         {
             var kind = tp == sourcePersonaId ? StanceTargetKind.Self : StanceTargetKind.Participant;
             return new StanceRecord(
                 row.Id, row.Valence, row.Reasoning, row.Ts,
-                kind, tp, null, null, isCurrent, row.Origin, row.RunId, row.RetractsId);
+                kind, tp, null, null, isCurrent, row.Origin, row.RunId, row.RetractsId, isIntrinsic);
         }
         return new StanceRecord(
             row.Id, row.Valence, row.Reasoning, row.Ts,
             StanceTargetKind.Concept, null, row.ConceptName, row.ConceptDisplay, isCurrent,
-            row.Origin, row.RunId, row.RetractsId);
+            row.Origin, row.RunId, row.RetractsId, isIntrinsic);
     }
 
     // All STANCE edges authored by one Participant, newest first. Single read-only Cypher —
@@ -827,6 +835,210 @@ public sealed class MemoryRepository(
                 }
 
                 // Absent origin = pre-attribution edge = curator (the only writer back then).
+                var origin = Get(7) switch
+                {
+                    "consolidation" => StanceOrigin.Consolidation,
+                    "retract" => StanceOrigin.Retract,
+                    _ => StanceOrigin.Curator,
+                };
+                var runId = Guid.TryParse(Get(8), out var run) ? run : (Guid?)null;
+                var retractsId = Guid.TryParse(Get(9), out var retr) ? retr : (Guid?)null;
+
+                rows.Add(new StanceEdgeRow(
+                    id, valence, reasoning, ts, targetPersonaId, conceptName, conceptDisplay,
+                    origin, runId, retractsId));
+            }
+
+            return rows;
+        }
+        finally
+        {
+            await db.Database.CloseConnectionAsync();
+        }
+    }
+
+    // ─── Intrinsic Stances (ADR 0016, issue #91) ──────────────────────────────────────────
+
+    public async Task<Guid> AppendIntrinsicStanceAsync(
+        Guid personaId,
+        StanceTargetSpec target,
+        double valence,
+        string reasoning,
+        StanceAttribution? attribution,
+        CancellationToken ct)
+    {
+        var edgeId = Guid.NewGuid();
+        var nowIso = DateTimeOffset.UtcNow.ToString("o");
+        var valenceLiteral = Math.Clamp(valence, -1.0, 1.0)
+            .ToString("0.0###", CultureInfo.InvariantCulture);
+
+        var provenance = attribution?.Origin switch
+        {
+            StanceOrigin.Consolidation => $", origin: 'consolidation', run_id: '{attribution.RunId}'",
+            StanceOrigin.Retract => $", origin: 'retract', retracts: '{attribution.RetractsId}'",
+            _ => string.Empty,
+        };
+
+        var edgeProps =
+            $"{{ id: '{edgeId}', valence: {valenceLiteral}, reasoning: {CypherStr(reasoning)}, ts: '{nowIso}'{provenance} }}";
+
+        string sql;
+        if (target.Kind == StanceTargetKind.Concept)
+        {
+            var name = target.ConceptName ?? string.Empty;
+            var display = target.ConceptDisplay ?? name;
+            sql = $$"""
+                SELECT * FROM cypher('memory', $cy$
+                  MERGE (src:Persona {id: '{{personaId}}'})
+                  MERGE (c:Concept {name: {{CypherStr(name)}}})
+                  SET c.display = coalesce(c.display, {{CypherStr(display)}})
+                  CREATE (src)-[s:STANCE {{edgeProps}}]->(c)
+                  RETURN s.id
+                $cy$) AS (id ag_catalog.agtype)
+                """;
+        }
+        else
+        {
+            var targetPersonaId = target.Kind == StanceTargetKind.Self
+                ? personaId
+                : target.PersonaId ?? throw new ArgumentException(
+                    "Participant Stance target requires PersonaId.", nameof(target));
+            sql = $$"""
+                SELECT * FROM cypher('memory', $cy$
+                  MERGE (src:Persona {id: '{{personaId}}'})
+                  MERGE (tgt:Persona {id: '{{targetPersonaId}}'})
+                  CREATE (src)-[s:STANCE {{edgeProps}}]->(tgt)
+                  RETURN s.id
+                $cy$) AS (id ag_catalog.agtype)
+                """;
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await db.Database.OpenConnectionAsync(ct);
+        try
+        {
+            await ExecuteCypherAsync(db, sql, ct);
+        }
+        finally
+        {
+            await db.Database.CloseConnectionAsync();
+        }
+
+        logger.LogInformation(
+            "Appended Intrinsic Stance {EdgeId} from persona {PersonaId} ({Kind}) (origin {Origin})",
+            edgeId, personaId, target.Kind, attribution?.Origin ?? StanceOrigin.Curator);
+
+        return edgeId;
+    }
+
+    public async Task<IReadOnlyList<StanceRecord>> ListIntrinsicStancesAsync(
+        Guid personaId,
+        CancellationToken ct)
+    {
+        var rows = await FetchIntrinsicStanceEdgesAsync(personaId, ct);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var records = new List<StanceRecord>(rows.Count);
+        foreach (var row in rows)
+        {
+            var isCurrent = seen.Add(TargetKey(row));
+            records.Add(ToRecord(row, personaId, isCurrent, isIntrinsic: true));
+        }
+        return records;
+    }
+
+    public async Task<Guid?> PromoteStanceAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        Guid stanceId,
+        CancellationToken ct)
+    {
+        var rows = await FetchStanceEdgesAsync(partyId, sourcePersonaId, ct);
+        var original = rows.FirstOrDefault(r => r.Id == stanceId);
+        if (original is null)
+        {
+            return null;
+        }
+
+        // Re-target: Participant → underlying Persona (same id since Participant.persona_id
+        // IS the Persona id). Concept and Self targets carry over unchanged.
+        StanceTargetSpec intrinsicTarget;
+        if (original.ConceptName is { Length: > 0 })
+        {
+            intrinsicTarget = new StanceTargetSpec(
+                StanceTargetKind.Concept, null, original.ConceptName, original.ConceptDisplay);
+        }
+        else if (original.TargetPersonaId is Guid tp && tp == sourcePersonaId)
+        {
+            intrinsicTarget = new StanceTargetSpec(StanceTargetKind.Self, null, null, null);
+        }
+        else
+        {
+            // Participant target: re-point at the target's Persona (persona_id == Persona.id).
+            var targetPersonaId = original.TargetPersonaId
+                ?? throw new InvalidOperationException("Malformed edge: no target.");
+            intrinsicTarget = new StanceTargetSpec(
+                StanceTargetKind.Participant, targetPersonaId, null, null);
+        }
+
+        return await AppendIntrinsicStanceAsync(
+            sourcePersonaId, intrinsicTarget, original.Valence, original.Reasoning,
+            attribution: null, ct);
+    }
+
+    // All Intrinsic STANCE edges from one Persona node, newest first. Mirrors
+    // FetchStanceEdgesAsync but reads from (:Persona) and uses tgt.id for Persona targets.
+    private async Task<IReadOnlyList<StanceEdgeRow>> FetchIntrinsicStanceEdgesAsync(
+        Guid personaId, CancellationToken ct)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await db.Database.OpenConnectionAsync(ct);
+        try
+        {
+            var sql = $$"""
+                SELECT * FROM cypher('memory', $cy$
+                  MATCH (src:Persona {id: '{{personaId}}'})-[s:STANCE]->(tgt)
+                  RETURN s.id, s.valence, s.reasoning, s.ts, tgt.id, tgt.name, tgt.display,
+                         s.origin, s.run_id, s.retracts
+                  ORDER BY s.ts DESC
+                $cy$) AS (id text, valence text, reasoning text, ts text,
+                          target_persona_id text, concept_name text, concept_display text,
+                          origin text, run_id text, retracts text)
+                """;
+
+            var conn = (NpgsqlConnection)db.Database.GetDbConnection();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+
+            var rows = new List<StanceEdgeRow>();
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
+            {
+                string? Get(int i) => reader.IsDBNull(i) ? null : reader.GetString(i);
+
+                if (!Guid.TryParse(Get(0), out var id))
+                {
+                    continue;
+                }
+                var reasoning = Get(2);
+                if (string.IsNullOrWhiteSpace(reasoning))
+                {
+                    continue;
+                }
+                var valence = double.TryParse(Get(1), NumberStyles.Float, CultureInfo.InvariantCulture, out var v)
+                    ? Math.Clamp(v, -1.0, 1.0)
+                    : 0.0;
+                var ts = ParseIso(Get(3)) ?? DateTimeOffset.UtcNow;
+
+                var targetPersonaId = Guid.TryParse(Get(4), out var tp) ? tp : (Guid?)null;
+                var conceptName = Get(5);
+                var conceptDisplay = Get(6);
+
+                if (targetPersonaId is null && string.IsNullOrWhiteSpace(conceptName))
+                {
+                    continue;
+                }
+
                 var origin = Get(7) switch
                 {
                     "consolidation" => StanceOrigin.Consolidation,

--- a/backend/Services/Memory/StanceDtos.cs
+++ b/backend/Services/Memory/StanceDtos.cs
@@ -81,7 +81,8 @@ public sealed record StanceRecord(
     bool IsCurrent,
     StanceOrigin Origin = StanceOrigin.Curator,
     Guid? RunId = null,
-    Guid? RetractsId = null);
+    Guid? RetractsId = null,
+    bool IsIntrinsic = false);
 
 /// <summary>
 /// One latest-wins Stance line surfaced for the ambient <c># Where you stand</c> block

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -953,6 +953,84 @@
         }
       }
     },
+    "/parties/{partyId}/memory/participants/{personaId}/stances/{stanceId}/promote": {
+      "post": {
+        "tags": [
+          "Memory"
+        ],
+        "parameters": [
+          {
+            "name": "partyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "personaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "stanceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendStanceResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendStanceResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendStanceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/Party": {
       "get": {
         "tags": [
@@ -2571,6 +2649,133 @@
           }
         }
       }
+    },
+    "/Persona/{personaId}/stances": {
+      "get": {
+        "tags": [
+          "Persona"
+        ],
+        "parameters": [
+          {
+            "name": "personaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StanceRecord"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StanceRecord"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StanceRecord"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Persona"
+        ],
+        "parameters": [
+          {
+            "name": "personaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppendStanceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppendStanceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppendStanceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendStanceResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendStanceResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendStanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3529,6 +3734,10 @@
               "string"
             ],
             "format": "uuid"
+          },
+          "isIntrinsic": {
+            "type": "boolean",
+            "default": false
           }
         }
       },

--- a/docs/adr/0011-bench-probe-runner.md
+++ b/docs/adr/0011-bench-probe-runner.md
@@ -57,7 +57,8 @@ The bench host reuses the backend's registrations and swaps only the edges:
   bench coexists with a running Aspire stack). Bench state is ephemeral; every run
   seeds fresh.
 - **Memory subsystem**: `IMemoryRepository` is stubbed by default (PersonaGrain hangs
-  silently without a registration). Probes that target memory swap in the real one.
+  silently without a registration). Probes that target memory swap in the real one —
+  backed by an ephemeral Apache AGE container the bench owns (→ Amendment 2026-06-14).
 
 Everything between those edges — config grain, router, endpoint grains, decision/
 speaking/salience/emote services, prompt composition — is production code, untouched.
@@ -120,3 +121,50 @@ is gitignored — artifacts are working material, not fixtures.
 - **Eval tier**: when prompt quality needs scoring rather than reading, add a runner
   that executes existing probes N times and applies a rubric (heuristic or LLM-judge)
   over the artifacts. The artifact schema is the contract; keep it stable.
+
+## Amendment (2026-06-14): real memory is a bench-owned Testcontainers AGE
+
+The "swap in the real one" above stayed an unbuilt intent; memory-driven slices
+(recall, Stance, the union read behind #91) had no bench loop. The full loop —
+real DB *and* real model together — is the one slice nothing else reaches: the
+stub-DB probes compose prompts but never recall; the `IntrinsicStanceIntegrationTest`
+suite hits real AGE but with a `NullExtractor`, so it never sees a model react.
+
+**Decision.** Memory-needing probes get a real `MemoryRepository` over an **ephemeral
+Apache AGE container the bench starts itself** via Testcontainers
+(`Testcontainers.PostgreSql`, `apache/age` image). Non-memory probes keep the stub.
+`doctor` reports `memory: LIVE (testcontainers)` vs `memory: stubbed`, mirroring the
+LLM `LIVE`/tier-0 report.
+
+**Why bench owns the container, not Aspire.** Aspire orchestrates long-running
+services; the bench is a one-shot, arg-driven CLI — an impedance mismatch. Connecting
+to the AppHost's DB would couple the bench to Aspire being up and to discovering its
+connection string (`.env`/user-secrets, port 5455). Testcontainers makes the bench
+self-contained, exactly as it already owns its own off-port silo: a **random host
+port** sidesteps any 5455 collision with a running AppHost, `GetConnectionString()` is
+the single source of truth (no discovery), and Ryuk reaps the container on exit. The
+bench's "seconds, no Aspire, no browser" property now holds even for the full memory
+loop — it needs only Docker, and only for memory probes.
+
+**Gating preserves tier-0.** A probe declares it `RequiresMemory`; only those start a
+container. Prompt-composition probes stay infra- and Docker-free — the degraded-but-
+useful tier-0 mode is load-bearing, not a fallback to erode. Docker absent when a probe
+needs memory → loud fall back to the stub, never a hang.
+
+**Schema via the shared C# ensure, not the docker init scripts.** Bench uses in-memory
+grain storage, so the Orleans DDL in `docker-entrypoint-initdb.d/01–04` is dead weight,
+and bind-mounting the init dir couples the bench to init-script breakage over a
+CWD-fragile path. `backend-test`'s `MemoryGraphFixture.EnsureMemoryGraphSchemaAsync`
+already builds the `memory` graph + vlabels/elabels (incl. `STANCE`) idempotently and
+is proven against #91 — extract it to a helper both the fixture and the bench call.
+
+**Ephemeral by default.** The container disposes with the host; each run seeds fresh,
+preserving clean-diff artifacts. `.WithReuse(true)` is a later opt-in for loop speed and
+forces per-run GUID namespacing (a reused graph accumulates). A *persistent data volume*
+— especially the AppHost's `partytown-pgdata` — is rejected: it collides with Aspire's
+postmaster and defeats determinism.
+
+**Boundary held.** This does not make the bench an integration-test harness. The
+integration suite asserts correctness over real AGE, CI-gated; the bench observes —
+emitting Probe Artifacts, never asserting. Same infra, different output contract; if
+that line blurs the bench rots into a slow, flaky test suite.

--- a/frontend/src/api/model/stanceRecord.ts
+++ b/frontend/src/api/model/stanceRecord.ts
@@ -26,4 +26,5 @@ export interface StanceRecord {
     runId?: string | null;
     /** @nullable */
     retractsId?: string | null;
+    isIntrinsic?: boolean;
 }

--- a/frontend/src/api/party-zone.ts
+++ b/frontend/src/api/party-zone.ts
@@ -3917,6 +3917,189 @@ export const usePostPartiesPartyIdMemoryConsolidate = <
     );
 };
 
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse201TextPlain =
+    {
+        data: AppendStanceResponse;
+        status: 201;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse201ApplicationJson =
+    {
+        data: AppendStanceResponse;
+        status: 201;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse201TextJson =
+    {
+        data: AppendStanceResponse;
+        status: 201;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse404TextPlain =
+    {
+        data: ProblemDetails;
+        status: 404;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse404ApplicationJson =
+    {
+        data: ProblemDetails;
+        status: 404;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse404TextJson =
+    {
+        data: ProblemDetails;
+        status: 404;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponseSuccess =
+    (
+        | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse201TextPlain
+        | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse201ApplicationJson
+        | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse201TextJson
+    ) & {
+        headers: Headers;
+    };
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponseError =
+    (
+        | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse404TextPlain
+        | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse404ApplicationJson
+        | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse404TextJson
+    ) & {
+        headers: Headers;
+    };
+
+export type postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse =
+    | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponseSuccess
+    | postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponseError;
+
+export const getPostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteUrl =
+    (partyId: string, personaId: string, stanceId: string) => {
+        return `/api/parties/${partyId}/memory/participants/${personaId}/stances/${stanceId}/promote`;
+    };
+
+export const postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote =
+    async (
+        partyId: string,
+        personaId: string,
+        stanceId: string,
+        options?: RequestInit,
+    ): Promise<postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse> => {
+        return customFetch<postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteResponse>(
+            getPostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteUrl(
+                partyId,
+                personaId,
+                stanceId,
+            ),
+            {
+                ...options,
+                method: 'POST',
+            },
+        );
+    };
+
+export const getPostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteMutationOptions =
+    <TError = ProblemDetails, TContext = unknown>(options?: {
+        mutation?: UseMutationOptions<
+            Awaited<
+                ReturnType<
+                    typeof postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote
+                >
+            >,
+            TError,
+            { partyId: string; personaId: string; stanceId: string },
+            TContext
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    }): UseMutationOptions<
+        Awaited<
+            ReturnType<
+                typeof postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote
+            >
+        >,
+        TError,
+        { partyId: string; personaId: string; stanceId: string },
+        TContext
+    > => {
+        const mutationKey = [
+            'postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote',
+        ];
+        const { mutation: mutationOptions, request: requestOptions } = options
+            ? options.mutation &&
+              'mutationKey' in options.mutation &&
+              options.mutation.mutationKey
+                ? options
+                : { ...options, mutation: { ...options.mutation, mutationKey } }
+            : { mutation: { mutationKey }, request: undefined };
+
+        const mutationFn: MutationFunction<
+            Awaited<
+                ReturnType<
+                    typeof postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote
+                >
+            >,
+            { partyId: string; personaId: string; stanceId: string }
+        > = (props) => {
+            const { partyId, personaId, stanceId } = props ?? {};
+
+            return postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote(
+                partyId,
+                personaId,
+                stanceId,
+                requestOptions,
+            );
+        };
+
+        return { mutationFn, ...mutationOptions };
+    };
+
+export type PostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteMutationResult =
+    NonNullable<
+        Awaited<
+            ReturnType<
+                typeof postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote
+            >
+        >
+    >;
+
+export type PostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteMutationError =
+    ProblemDetails;
+
+export const usePostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote =
+    <TError = ProblemDetails, TContext = unknown>(
+        options?: {
+            mutation?: UseMutationOptions<
+                Awaited<
+                    ReturnType<
+                        typeof postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote
+                    >
+                >,
+                TError,
+                { partyId: string; personaId: string; stanceId: string },
+                TContext
+            >;
+            request?: SecondParameter<typeof customFetch>;
+        },
+        queryClient?: QueryClient,
+    ): UseMutationResult<
+        Awaited<
+            ReturnType<
+                typeof postPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromote
+            >
+        >,
+        TError,
+        { partyId: string; personaId: string; stanceId: string },
+        TContext
+    > => {
+        return useMutation(
+            getPostPartiesPartyIdMemoryParticipantsPersonaIdStancesStanceIdPromoteMutationOptions(
+                options,
+            ),
+            queryClient,
+        );
+    };
+
 export type getPartyResponse200TextPlain = {
     data: PartyInfo[];
     status: 200;
@@ -10305,3 +10488,473 @@ export function useGetPersonaWsSuspense<
 
     return { ...query, queryKey: queryOptions.queryKey };
 }
+
+export type getPersonaPersonaIdStancesResponse200TextPlain = {
+    data: StanceRecord[];
+    status: 200;
+};
+
+export type getPersonaPersonaIdStancesResponse200ApplicationJson = {
+    data: StanceRecord[];
+    status: 200;
+};
+
+export type getPersonaPersonaIdStancesResponse200TextJson = {
+    data: StanceRecord[];
+    status: 200;
+};
+
+export type getPersonaPersonaIdStancesResponseSuccess = (
+    | getPersonaPersonaIdStancesResponse200TextPlain
+    | getPersonaPersonaIdStancesResponse200ApplicationJson
+    | getPersonaPersonaIdStancesResponse200TextJson
+) & {
+    headers: Headers;
+};
+
+export type getPersonaPersonaIdStancesResponse =
+    getPersonaPersonaIdStancesResponseSuccess;
+
+export const getGetPersonaPersonaIdStancesUrl = (personaId: string) => {
+    return `/api/Persona/${personaId}/stances`;
+};
+
+export const getPersonaPersonaIdStances = async (
+    personaId: string,
+    options?: RequestInit,
+): Promise<getPersonaPersonaIdStancesResponse> => {
+    return customFetch<getPersonaPersonaIdStancesResponse>(
+        getGetPersonaPersonaIdStancesUrl(personaId),
+        {
+            ...options,
+            method: 'GET',
+        },
+    );
+};
+
+export const getGetPersonaPersonaIdStancesQueryKey = (personaId: string) => {
+    return [`/api/Persona/${personaId}/stances`] as const;
+};
+
+export const getGetPersonaPersonaIdStancesQueryOptions = <
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+) => {
+    const { query: queryOptions, request: requestOptions } = options ?? {};
+
+    const queryKey =
+        queryOptions?.queryKey ??
+        getGetPersonaPersonaIdStancesQueryKey(personaId);
+
+    const queryFn: QueryFunction<
+        Awaited<ReturnType<typeof getPersonaPersonaIdStances>>
+    > = ({ signal }) =>
+        getPersonaPersonaIdStances(personaId, { signal, ...requestOptions });
+
+    return {
+        queryKey,
+        queryFn,
+        enabled: !!personaId,
+        ...queryOptions,
+    } as UseQueryOptions<
+        Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+        TError,
+        TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetPersonaPersonaIdStancesQueryResult = NonNullable<
+    Awaited<ReturnType<typeof getPersonaPersonaIdStances>>
+>;
+export type GetPersonaPersonaIdStancesQueryError = unknown;
+
+export function useGetPersonaPersonaIdStances<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options: {
+        query: Partial<
+            UseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        > &
+            Pick<
+                DefinedInitialDataOptions<
+                    Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                    TError,
+                    Awaited<ReturnType<typeof getPersonaPersonaIdStances>>
+                >,
+                'initialData'
+            >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetPersonaPersonaIdStances<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        > &
+            Pick<
+                UndefinedInitialDataOptions<
+                    Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                    TError,
+                    Awaited<ReturnType<typeof getPersonaPersonaIdStances>>
+                >,
+                'initialData'
+            >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetPersonaPersonaIdStances<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+};
+
+export function useGetPersonaPersonaIdStances<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+} {
+    const queryOptions = getGetPersonaPersonaIdStancesQueryOptions(
+        personaId,
+        options,
+    );
+
+    const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+        TData,
+        TError
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+    return { ...query, queryKey: queryOptions.queryKey };
+}
+
+export const getGetPersonaPersonaIdStancesSuspenseQueryOptions = <
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseSuspenseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+) => {
+    const { query: queryOptions, request: requestOptions } = options ?? {};
+
+    const queryKey =
+        queryOptions?.queryKey ??
+        getGetPersonaPersonaIdStancesQueryKey(personaId);
+
+    const queryFn: QueryFunction<
+        Awaited<ReturnType<typeof getPersonaPersonaIdStances>>
+    > = ({ signal }) =>
+        getPersonaPersonaIdStances(personaId, { signal, ...requestOptions });
+
+    return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+        TError,
+        TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetPersonaPersonaIdStancesSuspenseQueryResult = NonNullable<
+    Awaited<ReturnType<typeof getPersonaPersonaIdStances>>
+>;
+export type GetPersonaPersonaIdStancesSuspenseQueryError = unknown;
+
+export function useGetPersonaPersonaIdStancesSuspense<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options: {
+        query: Partial<
+            UseSuspenseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetPersonaPersonaIdStancesSuspense<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseSuspenseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetPersonaPersonaIdStancesSuspense<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseSuspenseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+};
+
+export function useGetPersonaPersonaIdStancesSuspense<
+    TData = Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+    TError = unknown,
+>(
+    personaId: string,
+    options?: {
+        query?: Partial<
+            UseSuspenseQueryOptions<
+                Awaited<ReturnType<typeof getPersonaPersonaIdStances>>,
+                TError,
+                TData
+            >
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+} {
+    const queryOptions = getGetPersonaPersonaIdStancesSuspenseQueryOptions(
+        personaId,
+        options,
+    );
+
+    const query = useSuspenseQuery(
+        queryOptions,
+        queryClient,
+    ) as UseSuspenseQueryResult<TData, TError> & {
+        queryKey: DataTag<QueryKey, TData, TError>;
+    };
+
+    return { ...query, queryKey: queryOptions.queryKey };
+}
+
+export type postPersonaPersonaIdStancesResponse201TextPlain = {
+    data: AppendStanceResponse;
+    status: 201;
+};
+
+export type postPersonaPersonaIdStancesResponse201ApplicationJson = {
+    data: AppendStanceResponse;
+    status: 201;
+};
+
+export type postPersonaPersonaIdStancesResponse201TextJson = {
+    data: AppendStanceResponse;
+    status: 201;
+};
+
+export type postPersonaPersonaIdStancesResponse400TextPlain = {
+    data: ProblemDetails;
+    status: 400;
+};
+
+export type postPersonaPersonaIdStancesResponse400ApplicationJson = {
+    data: ProblemDetails;
+    status: 400;
+};
+
+export type postPersonaPersonaIdStancesResponse400TextJson = {
+    data: ProblemDetails;
+    status: 400;
+};
+
+export type postPersonaPersonaIdStancesResponseSuccess = (
+    | postPersonaPersonaIdStancesResponse201TextPlain
+    | postPersonaPersonaIdStancesResponse201ApplicationJson
+    | postPersonaPersonaIdStancesResponse201TextJson
+) & {
+    headers: Headers;
+};
+export type postPersonaPersonaIdStancesResponseError = (
+    | postPersonaPersonaIdStancesResponse400TextPlain
+    | postPersonaPersonaIdStancesResponse400ApplicationJson
+    | postPersonaPersonaIdStancesResponse400TextJson
+) & {
+    headers: Headers;
+};
+
+export type postPersonaPersonaIdStancesResponse =
+    | postPersonaPersonaIdStancesResponseSuccess
+    | postPersonaPersonaIdStancesResponseError;
+
+export const getPostPersonaPersonaIdStancesUrl = (personaId: string) => {
+    return `/api/Persona/${personaId}/stances`;
+};
+
+export const postPersonaPersonaIdStances = async (
+    personaId: string,
+    appendStanceRequest: AppendStanceRequest,
+    options?: RequestInit,
+): Promise<postPersonaPersonaIdStancesResponse> => {
+    return customFetch<postPersonaPersonaIdStancesResponse>(
+        getPostPersonaPersonaIdStancesUrl(personaId),
+        {
+            ...options,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...options?.headers,
+            },
+            body: JSON.stringify(appendStanceRequest),
+        },
+    );
+};
+
+export const getPostPersonaPersonaIdStancesMutationOptions = <
+    TError = ProblemDetails,
+    TContext = unknown,
+>(options?: {
+    mutation?: UseMutationOptions<
+        Awaited<ReturnType<typeof postPersonaPersonaIdStances>>,
+        TError,
+        { personaId: string; data: AppendStanceRequest },
+        TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+    Awaited<ReturnType<typeof postPersonaPersonaIdStances>>,
+    TError,
+    { personaId: string; data: AppendStanceRequest },
+    TContext
+> => {
+    const mutationKey = ['postPersonaPersonaIdStances'];
+    const { mutation: mutationOptions, request: requestOptions } = options
+        ? options.mutation &&
+          'mutationKey' in options.mutation &&
+          options.mutation.mutationKey
+            ? options
+            : { ...options, mutation: { ...options.mutation, mutationKey } }
+        : { mutation: { mutationKey }, request: undefined };
+
+    const mutationFn: MutationFunction<
+        Awaited<ReturnType<typeof postPersonaPersonaIdStances>>,
+        { personaId: string; data: AppendStanceRequest }
+    > = (props) => {
+        const { personaId, data } = props ?? {};
+
+        return postPersonaPersonaIdStances(personaId, data, requestOptions);
+    };
+
+    return { mutationFn, ...mutationOptions };
+};
+
+export type PostPersonaPersonaIdStancesMutationResult = NonNullable<
+    Awaited<ReturnType<typeof postPersonaPersonaIdStances>>
+>;
+export type PostPersonaPersonaIdStancesMutationBody = AppendStanceRequest;
+export type PostPersonaPersonaIdStancesMutationError = ProblemDetails;
+
+export const usePostPersonaPersonaIdStances = <
+    TError = ProblemDetails,
+    TContext = unknown,
+>(
+    options?: {
+        mutation?: UseMutationOptions<
+            Awaited<ReturnType<typeof postPersonaPersonaIdStances>>,
+            TError,
+            { personaId: string; data: AppendStanceRequest },
+            TContext
+        >;
+        request?: SecondParameter<typeof customFetch>;
+    },
+    queryClient?: QueryClient,
+): UseMutationResult<
+    Awaited<ReturnType<typeof postPersonaPersonaIdStances>>,
+    TError,
+    { personaId: string; data: AppendStanceRequest },
+    TContext
+> => {
+    return useMutation(
+        getPostPersonaPersonaIdStancesMutationOptions(options),
+        queryClient,
+    );
+};

--- a/tools/bench/Bench.cs
+++ b/tools/bench/Bench.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using PartyTown.Grains.Generation;
+using PartyTown.Services.Memory;
 
 namespace PartyTown.Bench;
 
@@ -9,11 +10,17 @@ namespace PartyTown.Bench;
 /// <see cref="ProbeArtifact"/> to record observations into. The probe builds its cast and
 /// history with normal code, invokes the slice under design, and observes — it never asserts.
 /// </summary>
-public sealed class Bench(IGrainFactory grains, ILoggerFactory loggerFactory, ProbeArtifact artifact, CancellationToken cancellation = default)
+public sealed class Bench(IGrainFactory grains, ILoggerFactory loggerFactory, IMemoryRepository memory, ProbeArtifact artifact, CancellationToken cancellation = default)
 {
     public IGrainFactory Grains { get; } = grains;
     public ILoggerFactory LoggerFactory { get; } = loggerFactory;
     public ProbeArtifact Artifact { get; } = artifact;
+
+    /// <summary>The registered memory repository — the real <c>MemoryRepository</c> over the bench's
+    /// ephemeral AGE when the running probe declared <c>RequiresMemory</c> and Docker was reachable,
+    /// otherwise the no-op <see cref="StubMemoryRepository"/>. Only <c>RequiresMemory</c> probes
+    /// should touch it.</summary>
+    public IMemoryRepository Memory { get; } = memory;
 
     /// <summary>Fires at the probe deadline — pass into every async call so a timed-out probe
     /// actually stops instead of racing the artifact write.</summary>

--- a/tools/bench/BenchMemory.cs
+++ b/tools/bench/BenchMemory.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using PartyTown.Data;
+using Testcontainers.PostgreSql;
+
+namespace PartyTown.Bench;
+
+/// <summary>
+/// Owns the bench's ephemeral Apache AGE container (ADR 0011 amendment). Memory-needing probes
+/// get a real <c>MemoryRepository</c> over a one-shot container the bench starts itself — random
+/// host port (no 5455 collision with a running AppHost), <see cref="PostgreSqlContainer.GetConnectionString"/>
+/// as the single source of truth, Ryuk reaping it on exit. The Orleans DDL in
+/// <c>docker-entrypoint-initdb.d/01–04</c> is dead weight here (bench uses in-memory grain storage),
+/// so instead of bind-mounting the init dir we bring AGE up in C# and call the shared
+/// <see cref="MemoryGraphSchema"/>.
+/// </summary>
+public static class BenchMemory
+{
+    // Same image the Aspire AppHost runs, so bench AGE behaviour matches dev.
+    private const string Image = "apache/age:release_PG16_1.6.0";
+
+    public static PostgreSqlContainer NewContainer()
+        => new PostgreSqlBuilder().WithImage(Image).Build();
+
+    /// <summary>
+    /// Brings a freshly-started bare AGE container to the state the Aspire init scripts leave the
+    /// dev DB in: <c>CREATE EXTENSION age</c> (registers <c>ag_catalog</c> + the cypher()/agtype
+    /// machinery the bare image lacks), then the shared <see cref="MemoryGraphSchema"/>. The
+    /// <c>search_path</c> half of <c>05-age-setup.sql</c> is handled per-connection instead — see
+    /// <see cref="WithMemorySearchPath"/> — because a DB-level <c>ALTER DATABASE … SET</c> only
+    /// reaches sessions opened after it, which Npgsql connection pooling makes unreliable here.
+    /// </summary>
+    public static async Task PrepareSchemaAsync(string connectionString, CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(WithMemorySearchPath(connectionString));
+        await conn.OpenAsync(ct);
+
+        // CREATE EXTENSION registers ag_catalog + the cypher()/agtype machinery; LOAD (per session,
+        // also done by AgeOperatorInterceptor on the repo's connections) arms the operators.
+        await ExecAsync(conn, "CREATE EXTENSION IF NOT EXISTS age;", ct);
+        await ExecAsync(conn, "LOAD 'age';", ct);
+
+        await MemoryGraphSchema.EnsureAsync(conn, ct);
+    }
+
+    /// <summary>
+    /// A DbContext factory over the container connection, wired like production
+    /// (<c>backend/Program.cs</c>): <see cref="AgeOperatorInterceptor"/> fires <c>LOAD 'age'</c> on
+    /// every pooled-connection checkout. The connection also pins <c>search_path</c> so the repo's
+    /// unqualified <c>cypher()</c> resolves — the dev DB gets that from <c>05-age-setup.sql</c> at
+    /// the database level, which the bare bench container has no equivalent for.
+    /// </summary>
+    public static IDbContextFactory<AppDbContext> CreateDbContextFactory(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(WithMemorySearchPath(connectionString))
+            .AddInterceptors(new AgeOperatorInterceptor())
+            .Options;
+        return new BenchDbContextFactory(options);
+    }
+
+    // Npgsql applies the search_path in the startup packet on every physical connection, so each
+    // pooled session sees ag_catalog regardless of open order — unlike a DB-level ALTER.
+    private static string WithMemorySearchPath(string connectionString)
+        => new NpgsqlConnectionStringBuilder(connectionString) { SearchPath = "ag_catalog, public" }
+            .ConnectionString;
+
+    private static async Task ExecAsync(NpgsqlConnection conn, string sql, CancellationToken ct)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private sealed class BenchDbContextFactory(DbContextOptions<AppDbContext> options)
+        : IDbContextFactory<AppDbContext>
+    {
+        public AppDbContext CreateDbContext() => new(options);
+    }
+}

--- a/tools/bench/Doctor.cs
+++ b/tools/bench/Doctor.cs
@@ -12,11 +12,15 @@ namespace PartyTown.Bench;
 /// </summary>
 public static class Doctor
 {
-    public static async Task RunAsync(IGrainFactory grains)
+    public static async Task RunAsync(IGrainFactory grains, string memoryStatus)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
 
         Console.WriteLine("\n=== bench doctor ===\n");
+
+        // Mirrors the LLM LIVE/tier-0 report below: Program already tried to bring up the bench's
+        // ephemeral AGE container and handed us the verdict.
+        Console.WriteLine($"memory: {memoryStatus}\n");
 
         var config = grains.GetGrain<ILlmProviderConfigGrain>(0);
         List<LlmProviderEntry> providers;

--- a/tools/bench/Probes.cs
+++ b/tools/bench/Probes.cs
@@ -11,9 +11,16 @@ namespace PartyTown.Bench;
 public sealed class ProbeAttribute(string description) : Attribute
 {
     public string Description { get; } = description;
+
+    /// <summary>
+    /// Declares this probe needs a real <c>MemoryRepository</c> over AGE (recall / Stance / the
+    /// union read behind #91). Only such probes start the bench's ephemeral Testcontainers AGE
+    /// (ADR 0011 amendment); prompt-composition probes stay Docker-free (tier-0). Default false.
+    /// </summary>
+    public bool RequiresMemory { get; init; }
 }
 
-public sealed record ProbeInfo(string Name, string Description, Func<Bench, Task> Run);
+public sealed record ProbeInfo(string Name, string Description, bool RequiresMemory, Func<Bench, Task> Run);
 
 public static class ProbeRegistry
 {
@@ -32,6 +39,7 @@ public static class ProbeRegistry
                 return new ProbeInfo(
                     x.Method.Name,
                     x.Attr!.Description,
+                    x.Attr.RequiresMemory,
                     bench => (Task)x.Method.Invoke(null, [bench])!);
             })
             .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)

--- a/tools/bench/Probes/BenchCast.cs
+++ b/tools/bench/Probes/BenchCast.cs
@@ -9,13 +9,13 @@ namespace PartyTown.Bench.Probes;
 /// </summary>
 public static class BenchCast
 {
-    public static readonly Guid TimId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    public static readonly Guid SamId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     public static readonly Guid VladId = Guid.Parse("22222222-2222-2222-2222-222222222222");
     public static readonly Guid DeniseId = Guid.Parse("33333333-3333-3333-3333-333333333333");
     public static readonly Guid RoomId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
     /// <summary>The human in the room — view used in the participants list.</summary>
-    public static ParticipantView Tim => new(TimId, "Tim", DriverKind.User);
+    public static ParticipantView Sam => new(SamId, "Sam", DriverKind.User);
 
     /// <summary>Brooding, low chattiness — pings rarely.</summary>
     public static SelfView Vlad => new(
@@ -39,7 +39,7 @@ public static class BenchCast
 
     public static IReadOnlyList<ParticipantView> All => new[]
     {
-        Tim,
+        Sam,
         new ParticipantView(VladId, "Vlad", DriverKind.LLM),
         new ParticipantView(DeniseId, "Denise", DriverKind.LLM),
     };
@@ -54,7 +54,25 @@ public static class BenchCast
             MessageId = 1,
             Content = content,
             SenderType = "user",
-            SenderId = TimId,
+            SenderId = SamId,
+            ChatGroupId = RoomId,
+        },
+    };
+
+    /// <summary>One persona-authored message into the room. <c>SenderType "assistant"</c> means it
+    /// does NOT raise the cold-open floor (that fires only for "user"), so as long as the content
+    /// names no persona urge stays ≈0 — below the 0.9 auto-respond shortcut — and the decision model
+    /// still runs. Use when the *beat itself* must bear on a Stance or recollection: the target of
+    /// Vlad's Stance speaking is what turns a with/without diff from a plumbing check into a landing
+    /// judge. <paramref name="senderId"/> must be in <see cref="All"/> so the prompt resolves a name.</summary>
+    public static IReadOnlyList<ChatMessage> PersonaSays(Guid senderId, string content) => new[]
+    {
+        new ChatMessage
+        {
+            MessageId = 1,
+            Content = content,
+            SenderType = "assistant",
+            SenderId = senderId,
             ChatGroupId = RoomId,
         },
     };

--- a/tools/bench/Probes/BenchCast.cs
+++ b/tools/bench/Probes/BenchCast.cs
@@ -1,5 +1,4 @@
 using PartyTown.Model;
-using PartyTown.Services.Generation;
 
 namespace PartyTown.Bench.Probes;
 
@@ -15,36 +14,35 @@ public static class BenchCast
     public static readonly Guid DeniseId = Guid.Parse("33333333-3333-3333-3333-333333333333");
     public static readonly Guid RoomId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    /// <summary>The human in the room.</summary>
-    public static GenerationParticipant Tim => new()
-    {
-        Id = TimId,
-        Name = "Tim",
-        IsUser = true,
-        Chattiness = 0.5,
-    };
+    /// <summary>The human in the room — view used in the participants list.</summary>
+    public static ParticipantView Tim => new(TimId, "Tim", DriverKind.User);
 
     /// <summary>Brooding, low chattiness — pings rarely.</summary>
-    public static GenerationParticipant Vlad => new()
-    {
-        Id = VladId,
-        Name = "Vlad",
-        Bio = "A centuries-old vampire, world-weary and dry. Speaks little, lands hard when he does.",
-        Chattiness = 0.2,
-        Impulsivity = 0.3,
-    };
+    public static SelfView Vlad => new(
+        Id: VladId,
+        Name: "Vlad",
+        Driver: DriverKind.LLM,
+        Bio: "A centuries-old vampire, world-weary and dry. Speaks little, lands hard when he does.",
+        SystemPrompt: null,
+        Chattiness: 0.2,
+        Impulsivity: 0.3);
 
     /// <summary>Bubbly, high chattiness — chimes in often.</summary>
-    public static GenerationParticipant Denise => new()
-    {
-        Id = DeniseId,
-        Name = "Denise",
-        Bio = "An over-caffeinated event planner. Warm, fast-talking, never met a silence she liked.",
-        Chattiness = 0.8,
-        Impulsivity = 0.7,
-    };
+    public static SelfView Denise => new(
+        Id: DeniseId,
+        Name: "Denise",
+        Driver: DriverKind.LLM,
+        Bio: "An over-caffeinated event planner. Warm, fast-talking, never met a silence she liked.",
+        SystemPrompt: null,
+        Chattiness: 0.8,
+        Impulsivity: 0.7);
 
-    public static IReadOnlyList<GenerationParticipant> All => new[] { Tim, Vlad, Denise };
+    public static IReadOnlyList<ParticipantView> All => new[]
+    {
+        Tim,
+        new ParticipantView(VladId, "Vlad", DriverKind.LLM),
+        new ParticipantView(DeniseId, "Denise", DriverKind.LLM),
+    };
 
     /// <summary>One user message into a quiet room. The content is a statement (no '?', no
     /// persona names) so it does NOT trip the urge≥0.9 auto-respond shortcut — that would skip

--- a/tools/bench/Probes/DecisionProbes.cs
+++ b/tools/bench/Probes/DecisionProbes.cs
@@ -1,6 +1,6 @@
 using System.Text;
 using PartyTown.Model;
-using PartyTown.Services.Generation;
+using PartyTown.Services.ResponsePipeline;
 
 namespace PartyTown.Bench.Probes;
 
@@ -54,13 +54,13 @@ public static class DecisionProbes
     /// (chaos is excluded from it); only the ChaosScore component re-rolls per call.</summary>
     private static async Task RunDecision(
         Bench bench,
-        GenerationParticipant self,
+        SelfView self,
         IReadOnlyList<ChatMessage> history,
         IReadOnlyList<string>? recollections = null)
     {
         var service = new PersonaDecisionService(bench.Router, bench.Logger("PersonaDecisionService"));
 
-        var urge = PersonaDecisionService.CalculateResponseUrge(self, history, totalAiRoundsInGroup: 0);
+        var urge = UrgeMath.CalculateResponseUrge(self, history, totalAiRoundsInGroup: 0);
         bench.Observe($"{self.Name}.urge (Total deterministic; ChaosScore re-rolls per call)", new
         {
             urge.Total,

--- a/tools/bench/Probes/DecisionProbes.cs
+++ b/tools/bench/Probes/DecisionProbes.cs
@@ -22,8 +22,8 @@ public static class DecisionProbes
         // and we can watch whether Vlad picks one (memoryToReference) or declines.
         var vladMemories = new[]
         {
-            "Tim once spent a whole evening ranting about a meeting that could have been an email.",
-            "The last offsite Tim mentioned ended with someone crying by the trust-fall mat.",
+            "Sam once spent a whole evening ranting about a meeting that could have been an email.",
+            "The last offsite Sam mentioned ended with someone crying by the trust-fall mat.",
         };
 
         await RunDecision(bench, BenchCast.Vlad, history, vladMemories);
@@ -40,7 +40,7 @@ public static class DecisionProbes
                 MessageId = 1,
                 Content = "Vlad, you there?",
                 SenderType = "user",
-                SenderId = BenchCast.TimId,
+                SenderId = BenchCast.SamId,
                 ChatGroupId = BenchCast.RoomId,
             },
         };

--- a/tools/bench/Probes/StanceProbes.cs
+++ b/tools/bench/Probes/StanceProbes.cs
@@ -1,0 +1,168 @@
+using System.Text;
+using PartyTown.Model;
+using PartyTown.Services.Memory;
+using PartyTown.Services.ResponsePipeline;
+
+namespace PartyTown.Bench.Probes;
+
+/// <summary>
+/// Probes over the ambient "# Where you stand" block (ADR 0016, issue #91), in two tiers.
+/// <para>
+/// <see cref="Stance_WhereYouStand"/> is the Docker-free render half: it constructs
+/// <see cref="StanceLine"/> values directly — exactly the shape <c>RecallStancesAsync</c> returns —
+/// formats them through the real <see cref="StanceBlock"/>, and runs a cold-open twice (with vs.
+/// without stances) so the artifact diff isolates the Stance's effect on the decision. It never
+/// touches the graph, so it runs in tier-0.
+/// </para>
+/// <para>
+/// <see cref="Stance_IntrinsicTravelsToNewParty"/> (<c>RequiresMemory</c>) closes the loop against a
+/// real <see cref="MemoryRepository"/> over the bench's ephemeral AGE: it actually writes, promotes
+/// and re-targets a Stance, then reads it back across Parties before colouring the decision —
+/// exercising the union-read / Participant→Persona promotion that the render half can only mimic.
+/// </para>
+/// </summary>
+public static class StanceProbes
+{
+    [Probe("Where you stand: Vlad appraises a cold-open twice — once carrying intrinsic Stances (a monotone line toward Sam + an ambivalent fold toward Denise), once with none. Read the composed prompt for the '# Where you stand' block and the contrast fold, then judge whether the WITH-stance reasoning/voice takes colour the WITHOUT-stance run lacks.")]
+    public static async Task Stance_WhereYouStand(Bench bench)
+    {
+        // A statement (no '?', no persona names) → urge stays below the 0.9 auto-respond shortcut,
+        // so the real decision model runs and the Stance block can colour it (see ADR 0011 trap).
+        var history = BenchCast.ColdOpenHistory(
+            "i keep showing up to this group chat and i honestly couldn't tell you why anymore");
+        bench.Observe("scenario", new { history[0].Content });
+
+        // The lines recall would surface for Vlad this beat. A monotone Stance renders its reasoning
+        // verbatim; the Denise line carries a Contrast so StanceBlock folds it into one playable
+        // tension ("X — though you used to feel otherwise: Y") rather than two competing entries.
+        var stances = new[]
+        {
+            new StanceLine(
+                Reasoning: "Sam is the only mortal you've let close in a century — their weariness is yours",
+                Valence: 0.85),
+            new StanceLine(
+                Reasoning: "Denise's relentless cheer wears on you",
+                Valence: -0.4,
+                Contrast: "you used to envy how easily she fills a silence"),
+        };
+
+        // Mirror production exactly: ResponsePipeline maps recall's StanceLines through FormatLine
+        // before handing the strings to the decision service.
+        var stanceLines = stances.Select(StanceBlock.FormatLine).ToList();
+        bench.Observe("vlad.stanceLines (FormatLine output → fed as '# Where you stand')", stanceLines);
+        bench.Observe("vlad.stanceBlock (rendered block, for eyeballing the fold)",
+            StanceBlock.Render(stanceLines));
+
+        await RunDecision(bench, BenchCast.Vlad, history, stanceLines, label: "withStance");
+        await RunDecision(bench, BenchCast.Vlad, history, stances: null, label: "noStance");
+    }
+
+    /// <summary>
+    /// The #91 full loop end-to-end against a real <see cref="MemoryRepository"/> over the bench's
+    /// ephemeral AGE (ADR 0011 amendment): Vlad acquires a Stance toward Denise in one Party, the
+    /// curator promotes it to Intrinsic (Participant→Persona re-target), and in a *second* Party the
+    /// union read surfaces it — which then colours a live decision. This is the slice nothing else
+    /// reaches: the stub-DB probes never recall, and <c>IntrinsicStanceIntegrationTest</c> hits real
+    /// AGE but with a NullExtractor, so no model ever reacts. Read the recalled lines and the WITH vs
+    /// WITHOUT decision contrast to judge whether the travelled Stance actually lands.
+    /// </summary>
+    [Probe("Full #91 loop (real AGE): Vlad acquires a Stance toward Denise in party A, the curator promotes it to Intrinsic, and in a fresh party B — where Denise herself speaks the very cheer the Stance is about — the union read surfaces it and colours Vlad's live appraisal of HER line. Read partyB.recalledStances (did it travel?) and the withIntrinsic-vs-noStance decision diff (does the travelled weariness actually bend his read of Denise?).", RequiresMemory = true)]
+    public static async Task Stance_IntrinsicTravelsToNewParty(Bench bench)
+    {
+        var repo = bench.Memory;
+        var ct = bench.Cancellation;
+
+        // Fresh Party scopes per run keep the artifact clean against an accumulating graph if the
+        // container is ever reused (WithReuse); the cast Persona ids stay fixed for diffable output.
+        var partyA = Guid.NewGuid();
+        var partyB = Guid.NewGuid();
+        bench.Observe("scope", new { partyA, partyB, vlad = BenchCast.VladId, denise = BenchCast.DeniseId });
+
+        // 1. Party A — Vlad acquires a Stance toward Denise (a Participant-scoped STANCE edge).
+        var acquiredId = await repo.AppendStanceAsync(
+            partyA,
+            BenchCast.VladId,
+            new StanceTargetSpec(StanceTargetKind.Participant, BenchCast.DeniseId, null, null),
+            valence: -0.6,
+            reasoning: "Denise's relentless cheer wore you down across a long night in that first room",
+            attribution: null,
+            ct);
+        bench.Observe("partyA.acquiredStanceId", acquiredId);
+
+        // 2. Promote → re-points the target from this Party's Participant to Denise's underlying
+        // Persona, writing a Persona-scope edge that travels into every Party Vlad joins.
+        var intrinsicId = await repo.PromoteStanceAsync(partyA, BenchCast.VladId, acquiredId, ct);
+        bench.Observe("promotedIntrinsicStanceId", intrinsicId);
+
+        // 3. Party B — a fresh room Vlad has no acquired history in; only the Intrinsic edge can
+        // reach here, and only because Denise is present.
+        var recalled = await repo.RecallStancesAsync(
+            partyB,
+            BenchCast.VladId,
+            new[] { BenchCast.VladId, BenchCast.DeniseId },
+            anchorText: "",
+            limit: 10,
+            ct);
+        bench.Observe("partyB.recalledStances",
+            recalled.Select(l => new { l.Reasoning, l.Valence, l.Contrast }).ToList());
+
+        if (recalled.Count == 0)
+            bench.Observe("WARNING",
+                "no Stances recalled in party B — promotion or the cross-Party union read did not travel; "
+                + "the decision below has nothing to colour and the loop is broken.");
+
+        // 4. Render the travelled Stance and let it colour a live appraisal — but of a beat the
+        // Stance actually bears on: Denise (its target) speaking her relentless cheer. A neutral
+        // user cold-open would leave the Denise-targeted line with nothing to grip, so the diff
+        // would only prove the prompt carried the block — not that it bent Vlad's read. Her line
+        // names no persona (no "Vlad") and is an "assistant" turn, so urge stays below the 0.9
+        // auto-respond shortcut and the decision model still runs (ADR 0011 trap).
+        var stanceLines = recalled.Select(StanceBlock.FormatLine).ToList();
+        bench.Observe("partyB.stanceBlock (rendered '# Where you stand')", StanceBlock.Render(stanceLines));
+
+        var history = BenchCast.PersonaSays(
+            BenchCast.DeniseId,
+            "okay okay NEW room, fresh start, i love it!! who's bringing the energy today — let's actually make something happen!");
+        bench.Observe("partyB.scenario (Denise — the Stance's target — speaking)", new { history[0].Content });
+
+        await RunDecision(bench, BenchCast.Vlad, history, stanceLines, label: "partyB.withIntrinsic");
+        await RunDecision(bench, BenchCast.Vlad, history, stances: null, label: "partyB.noStance");
+    }
+
+    /// <summary>Runs one appraisal with an explicit Stance set and records the urge, the parsed
+    /// decision, and the raw stream under a label so the with/without runs diff cleanly. The
+    /// composed decision prompt (incl. the "# Where you stand" block) is captured automatically.</summary>
+    private static async Task RunDecision(
+        Bench bench,
+        SelfView self,
+        IReadOnlyList<ChatMessage> history,
+        IReadOnlyList<string>? stances,
+        string label)
+    {
+        var service = new PersonaDecisionService(bench.Router, bench.Logger("PersonaDecisionService"));
+
+        var urge = UrgeMath.CalculateResponseUrge(self, history, totalAiRoundsInGroup: 0);
+        bench.Observe($"{label}.{self.Name}.urge", new { urge.Total, urge.ColdOpenScore, urge.ChaosScore });
+
+        var raw = new StringBuilder();
+        var result = await service.ShouldRespondAsync(
+            self,
+            history,
+            BenchCast.All,
+            totalAiRoundsInGroup: 0,
+            onEvent: (_, data, _) => { raw.Append(data); return Task.CompletedTask; },
+            cancellationToken: bench.Cancellation,
+            recollections: null,
+            stances: stances);
+
+        bench.Observe($"{label}.{self.Name}.decision", new
+        {
+            result.Respond,
+            result.Instruction,
+            result.Reason,
+        });
+
+        if (raw.Length > 0)
+            bench.Observe($"{label}.{self.Name}.rawStream", raw.ToString());
+    }
+}

--- a/tools/bench/Program.cs
+++ b/tools/bench/Program.cs
@@ -7,6 +7,7 @@ using Orleans.Hosting;
 using PartyTown.Bench;
 using PartyTown.Configuration;
 using PartyTown.Services.Memory;
+using Testcontainers.PostgreSql;
 
 // The Bench (ADR 0011): a headless console host that runs Probes against the real grain path
 // and emits Probe Artifacts. `list`/no-args needs no host; `doctor` and probe runs spin up an
@@ -34,6 +35,45 @@ if (command is not "doctor")
     }
 }
 
+// Real memory is opt-in per probe (ADR 0011 amendment): only a RequiresMemory probe — or `doctor`,
+// which reports the tier — pays for the ephemeral AGE container. Prompt-composition probes stay
+// Docker-free (tier-0). Docker absent when a probe needs memory → loud fall back to the stub.
+var wantsMemory = command is "doctor" || (probe?.RequiresMemory ?? false);
+PostgreSqlContainer? postgres = null;
+string? memoryConnectionString = null;
+string memoryStatus;
+
+if (wantsMemory)
+{
+    try
+    {
+        Console.Error.WriteLine("memory: starting ephemeral AGE container (first run pulls the image)…");
+        postgres = BenchMemory.NewContainer();
+        await postgres.StartAsync();
+        memoryConnectionString = postgres.GetConnectionString();
+        await BenchMemory.PrepareSchemaAsync(memoryConnectionString, CancellationToken.None);
+        memoryStatus = "LIVE (testcontainers)";
+    }
+    catch (Exception ex)
+    {
+        memoryStatus = $"stubbed (no docker: {ex.Message})";
+        memoryConnectionString = null;
+        if (postgres is not null)
+        {
+            await postgres.DisposeAsync();
+            postgres = null;
+        }
+        if (probe?.RequiresMemory == true)
+            Console.Error.WriteLine(
+                $"!! probe '{probe.Name}' needs real memory but the AGE container could not start — " +
+                "falling back to StubMemoryRepository. Recall/Stance reads will be empty, NOT a real loop.");
+    }
+}
+else
+{
+    memoryStatus = "stubbed (not required by this probe)";
+}
+
 var builder = Host.CreateApplicationBuilder();
 
 // benchsettings.json ships beside the binary (copied to output); benchsettings.local.json is an
@@ -47,9 +87,21 @@ builder.Configuration
 builder.Services.AddLlmProviderOptions();
 builder.Services.AddHttpClient();
 builder.Services.AddMemoryCache();
-// Mandatory even though decision probes call the service directly — any host that can activate
-// PersonaGrain hangs silently without an IMemoryRepository registration.
-builder.Services.AddSingleton<IMemoryRepository, StubMemoryRepository>();
+
+// An IMemoryRepository registration is mandatory even for decision probes that call the service
+// directly — any host that can activate PersonaGrain hangs silently without one. RequiresMemory
+// probes (with Docker up) get the real repo over the bench's AGE container, wired exactly like
+// production (backend/Program.cs); everything else gets the no-op stub.
+if (memoryConnectionString is not null)
+{
+    builder.Services.AddSingleton<IMemoryExtractor, MemoryExtractor>();
+    builder.Services.AddSingleton(BenchMemory.CreateDbContextFactory(memoryConnectionString));
+    builder.Services.AddSingleton<IMemoryRepository, MemoryRepository>();
+}
+else
+{
+    builder.Services.AddSingleton<IMemoryRepository, StubMemoryRepository>();
+}
 
 builder.UseOrleans(silo =>
 {
@@ -75,16 +127,17 @@ try
 
     if (command is "doctor")
     {
-        await Doctor.RunAsync(grains);
+        await Doctor.RunAsync(grains, memoryStatus);
         return 0;
     }
 
     var loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
+    var memory = host.Services.GetRequiredService<IMemoryRepository>();
     var artifact = new ProbeArtifact(probe!.Name, DateTimeOffset.UtcNow);
 
     LlmCallRecorder.Reset();
     using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
-    var bench = new Bench(grains, loggerFactory, artifact, cts.Token);
+    var bench = new Bench(grains, loggerFactory, memory, artifact, cts.Token);
     var exit = 0;
     try
     {
@@ -110,6 +163,10 @@ try
 finally
 {
     await host.StopAsync();
+    // Ryuk reaps the container on process exit anyway, but dispose explicitly so a clean run leaves
+    // nothing behind (ephemeral-by-default, ADR 0011 amendment).
+    if (postgres is not null)
+        await postgres.DisposeAsync();
 }
 
 static void PrintProbes(IReadOnlyList<ProbeInfo> probes)

--- a/tools/bench/StubMemoryRepository.cs
+++ b/tools/bench/StubMemoryRepository.cs
@@ -15,15 +15,89 @@ public sealed class StubMemoryRepository : IMemoryRepository
         Guid partyId,
         Guid roomId,
         int messageId,
-        IReadOnlyList<ParticipantSnapshot> presentParticipants,
+        IReadOnlyList<ParticipantView> presentParticipants,
         IReadOnlyList<ChatMessage> recentContext,
         CancellationToken ct)
         => Task.FromResult(new MemoryCaptureResult(false, 0, 0));
 
-    public Task<IReadOnlyList<string>> RecallRecentSnippetsAsync(
+    public Task<IReadOnlyList<RecalledMemory>> RecallAsync(
         Guid personaId,
         Guid partyId,
+        IReadOnlyList<Guid> presentPersonaIds,
+        string anchorText,
         int limit,
         CancellationToken ct)
-        => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        => Task.FromResult<IReadOnlyList<RecalledMemory>>(Array.Empty<RecalledMemory>());
+
+    public Task StrengthenRecollectionAsync(Guid recollectionId, CancellationToken ct)
+        => Task.CompletedTask;
+
+    public Task<Guid> AppendStanceAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        StanceTargetSpec target,
+        double valence,
+        string reasoning,
+        StanceAttribution? attribution,
+        CancellationToken ct)
+        => Task.FromResult(Guid.NewGuid());
+
+    public Task<Guid?> RetractStanceAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        Guid stanceId,
+        CancellationToken ct)
+        => Task.FromResult<Guid?>(null);
+
+    public Task<IReadOnlyList<StanceRecord>> ListStancesAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<StanceRecord>>(Array.Empty<StanceRecord>());
+
+    public Task<IReadOnlyList<StanceLine>> RecallStancesAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        IReadOnlyList<Guid> presentPersonaIds,
+        string anchorText,
+        int limit,
+        CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<StanceLine>>(Array.Empty<StanceLine>());
+
+    public Task<Guid> AppendIntrinsicStanceAsync(
+        Guid personaId,
+        StanceTargetSpec target,
+        double valence,
+        string reasoning,
+        StanceAttribution? attribution,
+        CancellationToken ct)
+        => Task.FromResult(Guid.NewGuid());
+
+    public Task<IReadOnlyList<StanceRecord>> ListIntrinsicStancesAsync(
+        Guid personaId,
+        CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<StanceRecord>>(Array.Empty<StanceRecord>());
+
+    public Task<Guid?> PromoteStanceAsync(
+        Guid partyId,
+        Guid sourcePersonaId,
+        Guid stanceId,
+        CancellationToken ct)
+        => Task.FromResult<Guid?>(null);
+
+    public Task<ConsolidationBatch> GetUnconsolidatedRecollectionsAsync(
+        Guid partyId,
+        Guid personaId,
+        CancellationToken ct)
+        => Task.FromResult(new ConsolidationBatch(null, Array.Empty<UnconsolidatedRecollection>()));
+
+    public Task AdvanceConsolidationWatermarkAsync(
+        Guid partyId,
+        Guid personaId,
+        DateTimeOffset watermark,
+        CancellationToken ct)
+        => Task.CompletedTask;
+
+    public Task<MemoryGraphDto> GetPartyMemoryGraphAsync(Guid partyId, CancellationToken ct)
+        => Task.FromResult(new MemoryGraphDto(Array.Empty<MemoryGraphNode>(), Array.Empty<MemoryGraphLink>()));
 }

--- a/tools/bench/bench.csproj
+++ b/tools/bench/bench.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="11.0.0-preview.3.26207.106" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="10.0.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Promote acquired Stances to intrinsic scope: integration tests + API endpoint (Participant→Persona re-target).
- Bench probe tool improvements, including renaming the human cast member `Tim` → `Sam` across the bench probes (`BenchCast`, `DecisionProbes`, `StanceProbes`) so the fixtures don't carry a real maintainer's name. GUIDs unchanged → artifacts still diff cleanly.

## Test plan
- `dotnet build tools/bench/bench.csproj` — clean (pre-existing warnings only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intrinsic stances (persona-level beliefs) that persist across parties.
  * Added API endpoints to list and append intrinsic stances.
  * Added an endpoint to promote an acquired stance to intrinsic scope.
* **Bug Fixes & Improvements**
  * Updated stance recall to include both acquired and intrinsic stance history in a unified ordering.
* **Tests**
  * Added integration coverage for intrinsic stance creation, rendering/recall behavior across parties, and promotion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->